### PR TITLE
Various updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+lib
+node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "extends": ["eslint:recommended", "prettier"],
+  "plugins": ["prettier"],
+  "parserOptions": {
+    "ecmaVersion": 2017,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "modules": true
+    }
+  },
+  "rules": {
+    "prettier/prettier": ["error", { "singleQuote": true }],
+    "indent": ["error", 2],
+    "no-console": "off"
+  }
+}

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,0 +1,3 @@
+timeout: 10000
+require: source-map-support/register
+recursive: true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "auto",
 }

--- a/main.js
+++ b/main.js
@@ -22,11 +22,15 @@ program
   )
   .arguments('<file> [languages...]')
   .action(function (file, languages, cmd) {
-    run(file, languages || ['python'], {
-      output: cmd.outputdir,
-      parserName: cmd.parser,
-      templateFile: cmd.template,
-      fileExt: cmd.extension,
-    });
+    try {
+      run(file, languages && languages.length > 0 ? languages : ['python'], {
+        output: cmd.outputdir,
+        parserName: cmd.parser,
+        templateFile: cmd.template,
+        fileExt: cmd.extension,
+      });
+    } catch (error) {
+      console.error(error.message);
+    }
   })
   .parse(process.argv);

--- a/main.js
+++ b/main.js
@@ -1,22 +1,27 @@
 #!/usr/bin/env node
 
-require('source-map-support').install()
+require('source-map-support').install();
 
 const program = require('commander');
 
 const run = require('./lib/run').run;
 const version = require('./package.json').version;
 
-
 program
   .version(version)
   // TODO: Add valid parser names automatically:
-  .option('-p, --parser [parser]', 'The name of the parser to use, either "json" or "python".')
+  .option(
+    '-p, --parser [parser]',
+    'The name of the parser to use, either "json" or "python".'
+  )
   .option('-o, --outputdir [outputdir]', 'The output directory.')
   .option('-t, --template [template]', 'a template file to use.')
-  .option('-e, --extension [extension]', 'The file extension to use for the output.')
+  .option(
+    '-e, --extension [extension]',
+    'The file extension to use for the output.'
+  )
   .arguments('<file> [languages...]')
-  .action(function(file, languages, cmd) {
+  .action(function (file, languages, cmd) {
     run(file, languages || ['python'], {
       output: cmd.outputdir,
       parserName: cmd.parser,
@@ -24,4 +29,4 @@ program
       fileExt: cmd.extension,
     });
   })
-  .parse(process.argv)
+  .parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,67 +4,445 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@phosphor/algorithm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.1.2.tgz",
-      "integrity": "sha1-/R3pEEyafzTpKGRYbd8ufy53eeg="
-    },
-    "@phosphor/signaling": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.2.tgz",
-      "integrity": "sha1-P8+Xyojji/s1f+j+a/dRM0elFKk=",
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
       "requires": {
-        "@phosphor/algorithm": "^1.1.2"
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/core": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.3.tgz",
+      "integrity": "sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.9.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+      "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.3.tgz",
+      "integrity": "sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+      "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+      "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
+    "@lumino/algorithm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.2.3.tgz",
+      "integrity": "sha512-XBJ/homcm7o8Y9G6MzYvf0FF7SVqUCzvkIO01G2mZhCOnkZZhZ9c4uNOcE2VjSHNxHv2WU0l7d8rdhyKhmet+A=="
+    },
+    "@lumino/signaling": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.3.5.tgz",
+      "integrity": "sha512-6jniKrLrJOXKJmaJyU7hr6PBzE4GJ5Wms5hc/yzNKKDBxGSEPdtNJlW3wTNUuSTTtF/9ItN8A8ZC/G0yIu53Tw==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3"
       }
     },
     "@types/chai": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.3.tgz",
-      "integrity": "sha512-f5dXGzOJycyzSMdaXVhiBhauL4dYydXwVpavfQ1mVCaGjR56a9QfklXObUxlIY9bGTmCPHEEZ04I16BZ/8w5ww==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.2.tgz",
-      "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-YeDiSEzznwZwwp766SJ6QlrTyBYUGPSIwmREHVTmktUYiT/WADdWtpt9iH0KuUSf8lZLdI4lP0X6PBzPo5//JQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
       "dev": true
     },
     "@types/node": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
-      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
+      "version": "13.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz",
+      "integrity": "sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==",
       "dev": true
     },
     "@types/nunjucks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.0.0.tgz",
-      "integrity": "sha512-Msxi0MEZbsQlqx9oscKWwe6N2d4QerzXgGEzgMop4+RNFlO0PvhGpwJHXdTLUWz6GaZEOrNUsBBDNNYwKTgMJw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.1.3.tgz",
+      "integrity": "sha512-42IiIIBdoB7ZDwCVhCWYT4fMCj+4TeacuVgh7xyT2du5EhkpA+OFeeDdYTFCUt1MrHb8Aw7ZqFvr8s1bwP9l8w==",
       "dev": true
     },
     "a-sync-waterfall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
-      "integrity": "sha1-OOgxnXk3niRiiEW1O5ZyKyng5Hw="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
     },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "optional": true
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^3.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "asap": {
       "version": "2.0.6",
@@ -77,27 +455,22 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "optional": true
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-      "optional": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -110,27 +483,62 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-    },
-    "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+    "caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        }
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "check-error": {
@@ -139,165 +547,131 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
-    "chokidar": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-      "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
-      "optional": true,
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
-        "anymatch": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-          "optional": true,
-          "requires": {
-            "micromatch": "^2.1.5",
-            "normalize-path": "^2.0.0"
-          }
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
-        "arr-diff": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "optional": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "optional": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "optional": true,
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "optional": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "optional": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "optional": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "optional": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "optional": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "color-name": "1.1.3"
       }
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "optional": true
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+      "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -308,10 +682,70 @@
         "type-detect": "^4.0.0"
       }
     },
+    "default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^4.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -320,92 +754,103 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "optional": true,
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
       },
       "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "optional": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "optional": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "optional": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "optional": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
         }
       }
     },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "optional": true
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "optional": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "optional": true,
+    "foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
+    "fromentries": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
+      "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
+    },
     "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+        }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-func-name": {
@@ -415,9 +860,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -428,44 +873,16 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "optional": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "optional": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "growl": {
       "version": "1.10.5",
@@ -473,16 +890,67 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "hasha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+      "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.1.tgz",
+      "integrity": "sha512-hNX23TjWwD3q56HpWjUHOKj1+4KKlnjv9PcmBUYKVpga+2cnb9nDx/B1o0yO4n+RZXZdiNxzx6B24C9aNMTkkQ==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -496,75 +964,236 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
     },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "optional": true,
-      "requires": {
-        "binary-extensions": "^1.0.0"
-      }
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "optional": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "optional": true,
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "optional": true
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "is-extglob": "^2.1.1"
       }
     },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "optional": true
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
-    "is-primitive": {
+    "is-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "optional": true
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
     },
-    "isarray": {
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "optional": true
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^2.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+      "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-validation": {
       "version": "1.0.4",
@@ -575,912 +1204,463 @@
         "underscore": "1.3.3"
       }
     },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
-    "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-      "optional": true
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "chalk": "^2.4.2"
       }
-    },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "optional": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
+      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
       "dev": true,
       "requires": {
+        "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
         "growl": "1.10.5",
-        "he": "1.1.1",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
+        "mkdirp": "0.5.3",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         }
       }
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "nunjucks": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.1.3.tgz",
-      "integrity": "sha512-UtlKKAzg9vdtvURdNy9DjGhiB7qYf2R7Ez+hsucOQG5gYJexSggXSSZ+9IpSDyKOlWu/4rMVPH2oVoANOSqNKA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.1.tgz",
+      "integrity": "sha512-LYlVuC1ZNSalQQkLNNPvcgPt2M9FTY9bs39mTCuFXtqh7jWbYzhDlmz2M6onPiXEhdZo+b9anRhc+uBGuJZ2bQ==",
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
-        "chokidar": "^2.0.0",
-        "postinstall-build": "^5.0.1",
-        "yargs": "^3.32.0"
+        "chokidar": "^3.3.0",
+        "commander": "^3.0.2"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.3.0"
+          }
+        },
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "optional": true
+        },
+        "readdirp": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.0.7"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "nyc": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.8.0.tgz",
-      "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
+      "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.1.2",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^1.10.0",
-        "istanbul-lib-report": "^1.1.3",
-        "istanbul-lib-source-maps": "^1.2.3",
-        "istanbul-reports": "^1.4.0",
-        "md5-hex": "^1.2.0",
-        "merge-source-map": "^1.1.0",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.1",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.2.0",
-        "yargs": "11.1.0",
-        "yargs-parser": "^8.0.0"
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.0",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.0",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "uuid": "^3.3.3",
+        "yargs": "^15.0.2"
       },
       "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "append-transform": {
-          "version": "0.4.0",
-          "bundled": true,
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "default-require-extensions": "^1.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-union": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "assign-symbols": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "atob": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.22.0"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "base": {
-          "version": "0.11.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cache-base": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "class-utils": {
-          "version": "0.3.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
           }
         },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "collection-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
-          }
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "copy-descriptor": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.6",
-          "bundled": true,
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
         },
         "find-cache-dir": {
-          "version": "0.1.1",
-          "bundled": true,
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
           }
         },
         "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^4",
-            "signal-exit": "^3.0.0"
-          }
-        },
-        "fragment-cache": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-cache": "^0.2.2"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-value": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
         },
         "glob": {
-          "version": "7.1.2",
-          "bundled": true,
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1491,1842 +1671,122 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "has-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "has-values": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-odd": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-windows": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-coverage": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "append-transform": "^0.4.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "semver": "^5.3.0"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "3.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "^1.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.0.3"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
         "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "p-locate": "^4.1.0"
           }
         },
-        "lodash": {
-          "version": "4.17.10",
-          "bundled": true,
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "map-cache": {
-          "version": "0.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "map-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-visit": "^1.0.0"
-          }
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          }
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mixin-deep": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "nanomatch": {
-          "version": "1.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "arr-diff": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "array-unique": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-copy": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "object-visit": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "object.pick": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
+            "semver": "^6.0.0"
           }
         },
         "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "^2.2.0"
           }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "pascalcase": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
         },
         "path-exists": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
         },
         "pkg-dir": {
-          "version": "1.0.0",
-          "bundled": true,
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
+            "find-up": "^4.0.0"
           }
-        },
-        "posix-character-classes": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "bundled": true,
-          "dev": true
-        },
-        "regex-not": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-url": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ret": {
-          "version": "0.1.15",
-          "bundled": true,
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-regex": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ret": "~0.1.10"
-          }
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-value": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "snapdragon": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "snapdragon-node": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "snapdragon-util": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map-resolve": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "atob": "^2.0.0",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
-          }
-        },
-        "source-map-url": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "foreground-child": "^1.5.6",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "signal-exit": "^3.0.2",
-            "which": "^1.3.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "split-string": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^3.0.0"
-          }
-        },
-        "static-extend": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "test-exclude": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "micromatch": "^3.1.8",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
-          },
-          "dependencies": {
-            "arr-diff": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "array-unique": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "braces": {
-              "version": "2.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "expand-brackets": {
-              "version": "2.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "define-property": {
-                  "version": "0.2.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "^0.1.0"
-                  }
-                },
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                },
-                "is-accessor-descriptor": {
-                  "version": "0.1.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "kind-of": "^3.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-buffer": "^1.1.5"
-                      }
-                    }
-                  }
-                },
-                "is-data-descriptor": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "kind-of": "^3.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-buffer": "^1.1.5"
-                      }
-                    }
-                  }
-                },
-                "is-descriptor": {
-                  "version": "0.1.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-accessor-descriptor": "^0.1.6",
-                    "is-data-descriptor": "^0.1.4",
-                    "kind-of": "^5.0.0"
-                  }
-                },
-                "kind-of": {
-                  "version": "5.1.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "extglob": {
-              "version": "2.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "define-property": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "^1.0.0"
-                  }
-                },
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "fill-range": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
-              },
-              "dependencies": {
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "micromatch": {
-              "version": "3.1.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
-              }
-            }
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "to-object-path": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "to-regex": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              }
-            }
-          }
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "union-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "set-value": {
-              "version": "0.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
-              }
-            }
-          }
-        },
-        "unset-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "has-value": {
-              "version": "0.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
-              },
-              "dependencies": {
-                "isobject": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "isarray": "1.0.0"
-                  }
-                }
-              }
-            },
-            "has-values": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "urix": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "use": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "bundled": true,
-          "dev": true
         },
         "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true
         },
         "yargs": {
-          "version": "11.1.0",
-          "bundled": true,
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^4.2.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cliui": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "9.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "^4.1.0"
-              }
-            }
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
           }
         },
         "yargs-parser": {
-          "version": "8.1.0",
-          "bundled": true,
+          "version": "18.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
+          "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            }
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "optional": true,
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "once": {
@@ -3338,46 +1798,74 @@
         "wrappy": "1"
       }
     },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+    "p-limit": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "optional": true,
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "optional": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
+        "p-limit": "^2.0.0"
       }
+    },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "pathval": {
       "version": "1.1.0",
@@ -3385,166 +1873,251 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "postinstall-build": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz",
-      "integrity": "sha1-uRepB5smF42aJK9aXNjLSpkdEbk="
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "optional": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "optional": true
-    },
-    "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-      "optional": true,
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "optional": true
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "optional": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "optional": true,
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "optional": true
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "fromentries": "^1.2.0"
+      }
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "optional": true
+      "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "optional": true
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^5.0.0"
       }
     },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "type-detect": {
       "version": "4.0.8",
@@ -3552,10 +2125,19 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "underscore": {
@@ -3564,29 +2146,118 @@
       "integrity": "sha1-R6xTaD2vgyv6lS4XdEF9pHgXrkI=",
       "dev": true
     },
-    "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "wrappy": {
@@ -3595,23 +2266,101 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
     },
     "yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
       "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,6 +389,18 @@
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
+    "acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -399,11 +411,40 @@
         "indent-string": "^4.0.0"
       }
     },
+    "ajv": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
       "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -453,6 +494,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "at-least-node": {
@@ -510,6 +557,12 @@
         }
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -541,6 +594,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -551,6 +610,21 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -667,6 +741,15 @@
         }
       }
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -681,6 +764,12 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -705,6 +794,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -754,11 +852,275 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
+      "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
+          "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "find-up": {
       "version": "3.0.0",
@@ -785,6 +1147,34 @@
           "dev": true
         }
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -841,6 +1231,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -859,6 +1255,12 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -871,6 +1273,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -941,6 +1352,39 @@
       "integrity": "sha512-hNX23TjWwD3q56HpWjUHOKj1+4KKlnjv9PcmBUYKVpga+2cnb9nDx/B1o0yO4n+RZXZdiNxzx6B24C9aNMTkkQ==",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -968,6 +1412,79 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "is-callable": {
       "version": "1.1.5",
@@ -999,6 +1516,12 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.5",
@@ -1195,6 +1718,18 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-validation": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/json-validation/-/json-validation-1.0.4.tgz",
@@ -1202,6 +1737,16 @@
       "dev": true,
       "requires": {
         "underscore": "1.3.3"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "locate-path": {
@@ -1234,6 +1779,12 @@
       "requires": {
         "chalk": "^2.4.2"
       }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1415,6 +1966,30 @@
           }
         }
       }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -1798,6 +2373,35 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
     "p-limit": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
@@ -1843,6 +2447,15 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1878,6 +2491,27 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.1.tgz",
+      "integrity": "sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -1886,6 +2520,24 @@
       "requires": {
         "fromentries": "^1.2.0"
       }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -1923,6 +2575,16 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1932,10 +2594,34 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semver": {
@@ -1970,6 +2656,25 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -2086,6 +2791,58 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -2113,16 +2870,58 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "typedarray-to-buffer": {
@@ -2146,10 +2945,25 @@
       "integrity": "sha1-R6xTaD2vgyv6lS4XdEF9pHgXrkI=",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
     },
     "which": {
@@ -2209,6 +3023,12 @@
         }
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -2265,6 +3085,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,13 @@
   },
   "scripts": {
     "build": "tsc && node ./scripts/copy-files.js",
+    "lint": "eslint --fix .",
+    "lint:check": "eslint .",
     "manual": "npm run build && node main.js -o manual ./test/definitions/test2.py python js ts java",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
+    "prettier": "prettier --write \"(src|test|scripts)/**/*.[jt]s\"",
+    "prettier:check": "prettier --check \"(src|test|scripts)/**/*.[jt]s\"",
     "start": "node main.js",
     "test": "mocha",
     "test:cov": "nyc mocha",
@@ -62,9 +66,13 @@
     "@types/node": "^13.9.3",
     "@types/nunjucks": "^3.0.0",
     "chai": "^4.1.2",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-prettier": "^3.1.2",
     "json-validation": "^1.0.4",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
+    "prettier": "^2.0.1",
     "rimraf": "^3.0.2",
     "typescript": "^3.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "prettier": "prettier --write \"(src|test|scripts)/**/*.[jt]s\"",
     "prettier:check": "prettier --check \"(src|test|scripts)/**/*.[jt]s\"",
     "start": "node main.js",
-    "test": "mocha",
-    "test:cov": "nyc mocha",
+    "test": "mocha \"./test/test*.js\"",
+    "test:cov": "nyc mocha \"./test/test*.js\"",
     "update": "update-dependency --minimal --regex .*"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -2,69 +2,70 @@
   "name": "widget-gen",
   "version": "0.5.2",
   "description": "A node package for generating jupyter widget definitions from a JSON schema",
-  "main": "src/index.ts",
-  "bin": {
-    "widgetgen": "./main.js"
-  },
-  "directories": {
-    "test": "test",
-    "lib": "lib"
-  },
-  "scripts": {
-    "test": "mocha",
-    "test:cov": "nyc mocha",
-    "build": "tsc && node ./scripts/copy-files.js",
-    "start": "node main.js",
-    "manual": "npm run build && node main.js -o manual ./test/definitions/test2.py python js ts java",
-    "prepare": "npm run build",
-    "prepublishOnly": "npm test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/vidartf/widget-gen.git"
-  },
   "keywords": [
     "jupyter",
     "widgets",
     "generation"
   ],
-  "author": "Vidar Tonaas Fauske",
-  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/vidartf/widget-gen",
   "bugs": {
     "url": "https://github.com/vidartf/widget-gen/issues"
   },
-  "homepage": "https://github.com/vidartf/widget-gen",
-  "dependencies": {
-    "@phosphor/signaling": "^1.2.2",
-    "commander": "^2.13.0",
-    "fs-extra": "^6.0.1",
-    "nunjucks": "^3.1.0",
-    "source-map-support": "^0.5.3"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vidartf/widget-gen.git"
   },
-  "devDependencies": {
-    "@types/chai": "^4.1.3",
-    "@types/fs-extra": "^5.0.2",
-    "@types/mocha": "^5.2.0",
-    "@types/node": "^10.1.2",
-    "@types/nunjucks": "^3.0.0",
-    "chai": "^4.1.2",
-    "json-validation": "^1.0.4",
-    "mocha": "^5.2.0",
-    "nyc": "^11.8.0",
-    "rimraf": "^2.6.2",
-    "typescript": "~2.8.3"
+  "license": "BSD-3-Clause",
+  "author": "Vidar Tonaas Fauske",
+  "main": "src/index.ts",
+  "bin": {
+    "widgetgen": "./main.js"
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "build": "tsc && node ./scripts/copy-files.js",
+    "manual": "npm run build && node main.js -o manual ./test/definitions/test2.py python js ts java",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test",
+    "start": "node main.js",
+    "test": "mocha",
+    "test:cov": "nyc mocha",
+    "update": "update-dependency --minimal --regex .*"
   },
   "nyc": {
     "include": [
       "lib/**/*.js",
       "lib/**/*.jsx"
     ],
+    "instrument": true,
     "reporter": [
       "text-summary",
       "html",
       "lcov"
     ],
-    "sourceMap": true,
-    "instrument": true
+    "sourceMap": true
+  },
+  "dependencies": {
+    "@lumino/signaling": "^1.2.2",
+    "commander": "^5.0.0",
+    "fs-extra": "^9.0.0",
+    "nunjucks": "^3.1.0",
+    "source-map-support": "^0.5.3"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.1.3",
+    "@types/fs-extra": "^8.1.0",
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^13.9.3",
+    "@types/nunjucks": "^3.0.0",
+    "chai": "^4.1.2",
+    "json-validation": "^1.0.4",
+    "mocha": "^7.1.1",
+    "nyc": "^15.0.0",
+    "rimraf": "^3.0.2",
+    "typescript": "^3.8.3"
   }
 }

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -8,20 +8,18 @@ const baseDir = path.resolve(scriptDir, '..');
 const srcDir = path.resolve(baseDir, 'src');
 const buildDir = path.resolve(baseDir, 'lib');
 
-
 function copyParserHelpers() {
-    return fse.copy(
-        path.resolve(srcDir, 'parsers', 'python_parser.py'),
-        path.resolve(buildDir, 'parsers', 'python_parser.py')
-    ).then(function() {
-        console.log('Copied python parser helper to lib folder');
+  return fse
+    .copy(
+      path.resolve(srcDir, 'parsers', 'python_parser.py'),
+      path.resolve(buildDir, 'parsers', 'python_parser.py')
+    )
+    .then(function () {
+      console.log('Copied python parser helper to lib folder');
     });
 }
 
-
 if (require.main === module) {
-    // This script copies files after a build
-    Promise.all([
-        copyParserHelpers(),
-    ]);
+  // This script copies files after a build
+  Promise.all([copyParserHelpers()]);
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -132,41 +132,6 @@ export namespace Attributes {
   export type Attribute = DefinedAttribute | undefined;
 
   export type Properties = { [key: string]: Attribute };
-
-  /**
-   * Check whether the attribute defintion is for a union type.
-   */
-  export function isUnion(data: Attribute): data is IUnion {
-    return !!data && data.type === 'union';
-  }
-
-  /**
-   * Check whether the attribute defintion is for a widget reference type.
-   */
-  export function isWidgetRef(data: Attribute): data is IWidgetRef {
-    return !!data && data.type === 'widgetRef';
-  }
-
-  /**
-   * Check whether the attribute defintion is for an array/sequence type.
-   */
-  export function isArray(data: Attribute): data is IArray {
-    return !!data && data.type === 'array';
-  }
-
-  /**
-   * Check whether the attribute defintion is for an ndarray type.
-   */
-  export function isNDArray(data: Attribute): data is INDArray {
-    return !!data && data.type === 'ndarray';
-  }
-
-  /**
-   * Check whether the attribute defintion is for an dataunion type.
-   */
-  export function isDataUnion(data: Attribute): data is IDataUnion {
-    return !!data && data.type === 'dataunion';
-  }
 }
 
 /**
@@ -180,9 +145,9 @@ export function getSubDefinitions(
   data: Attributes.Attribute
 ): Attributes.Attribute[] {
   let directSubs;
-  if (Attributes.isUnion(data)) {
+  if (data?.type === 'union') {
     directSubs = data.oneOf;
-  } else if (Attributes.isArray(data) && data.items) {
+  } else if (data?.type === 'array' && data.items) {
     directSubs = Array.isArray(data.items) ? data.items : [data.items];
   } else {
     return [];
@@ -202,11 +167,11 @@ export function getSubDefinitions(
  * @returns {boolean} Whether the attribute definition contains a widget reference
  */
 export function hasWidgetRef(data: Attributes.Attribute): boolean {
-  if (Attributes.isWidgetRef(data)) {
+  if (data?.type === 'widgetRef') {
     return true;
   }
   for (let sub of getSubDefinitions(data)) {
-    if (Attributes.isWidgetRef(sub)) {
+    if (sub?.type === 'widgetRef') {
       return true;
     }
   }
@@ -221,14 +186,14 @@ export function hasWidgetRef(data: Attributes.Attribute): boolean {
  * @returns {MSet<string>} A set of the names of the referenced widgets.
  */
 export function getWidgetRefs(data: Attributes.Attribute): MSet<string> {
-  if (Attributes.isWidgetRef(data)) {
+  if (data?.type === 'widgetRef') {
     return new MSet(
       Array.isArray(data.widgetType) ? data.widgetType : [data.widgetType]
     );
   }
   return new MSet(
     getSubDefinitions(data).reduce((cum: string[], sub) => {
-      if (Attributes.isWidgetRef(sub)) {
+      if (sub?.type === 'widgetRef') {
         return cum.concat(
           Array.isArray(sub.widgetType) ? sub.widgetType : [sub.widgetType]
         );

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,33 +1,23 @@
-
-import {
-  MSet
-} from './setMethods';
-
+import { MSet } from './setMethods';
 
 /**
  * A self-contained widget definition.
  */
-export
-interface IWidget {
+export interface IWidget {
   properties?: {
     [key: string]: Attributes.Attribute;
-  },
+  };
   name: string;
   inherits: string[];
   localDependencies: string[];
   help?: string;
 }
 
-
-export
-namespace Attributes {
-
-
+export namespace Attributes {
   /**
    * Base structure for all attribute definitions.
    */
-  export
-  interface IBase {
+  export interface IBase {
     type: string;
     help?: string;
     allowNull?: boolean;
@@ -36,8 +26,7 @@ namespace Attributes {
   /**
    * Array/sequence attribute definition.
    */
-  export
-  interface IArray extends IBase {
+  export interface IArray extends IBase {
     type: 'array';
     default?: any[] | null;
     items?: DefinedAttribute[];
@@ -46,8 +35,7 @@ namespace Attributes {
   /**
    * Widget reference attribute definition.
    */
-  export
-  interface IWidgetRef extends IBase {
+  export interface IWidgetRef extends IBase {
     type: 'widgetRef';
     widgetType: string | string[];
     default?: null;
@@ -56,8 +44,7 @@ namespace Attributes {
   /**
    * Object/hashmap/dictionary attribute definition.
    */
-  export
-  interface IObject extends IBase {
+  export interface IObject extends IBase {
     type: 'object';
     default?: any | null;
   }
@@ -65,8 +52,7 @@ namespace Attributes {
   /**
    * String attribute definition.
    */
-  export
-  interface IString extends IBase {
+  export interface IString extends IBase {
     type: 'string';
     default?: string | null;
   }
@@ -74,8 +60,7 @@ namespace Attributes {
   /**
    * Floating point number attribute definition.
    */
-  export
-  interface IFloat extends IBase {
+  export interface IFloat extends IBase {
     type: 'float';
     default?: number | null;
   }
@@ -83,8 +68,7 @@ namespace Attributes {
   /**
    * Integer attribute definition.
    */
-  export
-  interface IInteger extends IBase {
+  export interface IInteger extends IBase {
     type: 'int';
     default?: number | null;
   }
@@ -92,8 +76,7 @@ namespace Attributes {
   /**
    * Boolean attribute definition.
    */
-  export
-  interface IBoolean extends IBase {
+  export interface IBoolean extends IBase {
     type: 'boolean';
     default?: boolean | null;
   }
@@ -101,12 +84,11 @@ namespace Attributes {
   /**
    * Numpy.ndarray-like attribute definition.
    */
-  export
-  interface INDArray extends IBase {
+  export interface INDArray extends IBase {
     type: 'ndarray';
     default?: any[] | null;
     shape?: number[];
-    dtype: string;  // TODO: Make enum
+    dtype: string; // TODO: Make enum
   }
 
   /**
@@ -114,19 +96,17 @@ namespace Attributes {
    *
    * See jupyter-datawidgets for details.
    */
-  export
-  interface IDataUnion extends IBase {
+  export interface IDataUnion extends IBase {
     type: 'dataunion';
     default?: any[] | null;
     shape?: number[];
-    dtype: string;  // TODO: Make enum
+    dtype: string; // TODO: Make enum
   }
 
   /**
    * Union attribute definition.
    */
-  export
-  interface IUnion extends IBase {
+  export interface IUnion extends IBase {
     type: 'union';
     oneOf: DefinedAttribute[];
   }
@@ -134,67 +114,60 @@ namespace Attributes {
   /**
    * An extended attribute definition.
    */
-  export
-  type DefinedAttribute = (
-    IArray | IObject | IWidgetRef |
-    IString | IFloat | IInteger |
-    IBoolean | IUnion | INDArray |
-    IDataUnion
-  );
+  export type DefinedAttribute =
+    | IArray
+    | IObject
+    | IWidgetRef
+    | IString
+    | IFloat
+    | IInteger
+    | IBoolean
+    | IUnion
+    | INDArray
+    | IDataUnion;
 
   /**
    * An attribute definition.
    */
-  export
-  type Attribute = DefinedAttribute | undefined;
+  export type Attribute = DefinedAttribute | undefined;
 
-
-  export
-  type Properties = {[key: string]: Attribute};
-
+  export type Properties = { [key: string]: Attribute };
 
   /**
    * Check whether the attribute defintion is for a union type.
    */
-  export
-  function isUnion(data: Attribute): data is IUnion {
+  export function isUnion(data: Attribute): data is IUnion {
     return !!data && data.type === 'union';
   }
 
   /**
    * Check whether the attribute defintion is for a widget reference type.
    */
-  export
-  function isWidgetRef(data: Attribute): data is IWidgetRef {
+  export function isWidgetRef(data: Attribute): data is IWidgetRef {
     return !!data && data.type === 'widgetRef';
   }
 
   /**
    * Check whether the attribute defintion is for an array/sequence type.
    */
-  export
-  function isArray(data: Attribute): data is IArray {
+  export function isArray(data: Attribute): data is IArray {
     return !!data && data.type === 'array';
   }
 
   /**
    * Check whether the attribute defintion is for an ndarray type.
    */
-  export
-  function isNDArray(data: Attribute): data is INDArray {
+  export function isNDArray(data: Attribute): data is INDArray {
     return !!data && data.type === 'ndarray';
   }
 
   /**
    * Check whether the attribute defintion is for an dataunion type.
    */
-  export
-  function isDataUnion(data: Attribute): data is IDataUnion {
+  export function isDataUnion(data: Attribute): data is IDataUnion {
     return !!data && data.type === 'dataunion';
   }
-
 }
-
 
 /**
  * Find all sub-definitions of an attribute defintion.
@@ -203,8 +176,9 @@ namespace Attributes {
  * @param {AttributeDef} data The attribute definition
  * @returns {AttributeDef[]} A flattened array of all sub-definitions
  */
-export
-function getSubDefinitions(data: Attributes.Attribute): Attributes.Attribute[] {
+export function getSubDefinitions(
+  data: Attributes.Attribute
+): Attributes.Attribute[] {
   let directSubs;
   if (Attributes.isUnion(data)) {
     directSubs = data.oneOf;
@@ -227,8 +201,7 @@ function getSubDefinitions(data: Attributes.Attribute): Attributes.Attribute[] {
  * @param {AttributeDef} data The attribute definition to check
  * @returns {boolean} Whether the attribute definition contains a widget reference
  */
-export
-function hasWidgetRef(data: Attributes.Attribute): boolean {
+export function hasWidgetRef(data: Attributes.Attribute): boolean {
   if (Attributes.isWidgetRef(data)) {
     return true;
   }
@@ -247,15 +220,20 @@ function hasWidgetRef(data: Attributes.Attribute): boolean {
  * @param {AttributeDef} data The atrtibute definition to check
  * @returns {MSet<string>} A set of the names of the referenced widgets.
  */
-export
-function getWidgetRefs(data: Attributes.Attribute): MSet<string> {
+export function getWidgetRefs(data: Attributes.Attribute): MSet<string> {
   if (Attributes.isWidgetRef(data)) {
-    return new MSet(Array.isArray(data.widgetType) ? data.widgetType : [data.widgetType]);
+    return new MSet(
+      Array.isArray(data.widgetType) ? data.widgetType : [data.widgetType]
+    );
   }
-  return new MSet(getSubDefinitions(data).reduce((cum: string[], sub) => {
-    if (Attributes.isWidgetRef(sub)) {
-      return cum.concat(Array.isArray(sub.widgetType) ? sub.widgetType : [sub.widgetType]);
-    }
-    return cum;
-  }, []));
+  return new MSet(
+    getSubDefinitions(data).reduce((cum: string[], sub) => {
+      if (Attributes.isWidgetRef(sub)) {
+        return cum.concat(
+          Array.isArray(sub.widgetType) ? sub.widgetType : [sub.widgetType]
+        );
+      }
+      return cum;
+    }, [])
+  );
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -21,6 +21,7 @@ export namespace Attributes {
     type: string;
     help?: string;
     allowNull?: boolean;
+    enum?: any[];
   }
 
   /**
@@ -82,6 +83,14 @@ export namespace Attributes {
   }
 
   /**
+   * Any attribute definition.
+   */
+  export interface IAny extends IBase {
+    type: 'any';
+    default?: any;
+  }
+
+  /**
    * Numpy.ndarray-like attribute definition.
    */
   export interface INDArray extends IBase {
@@ -122,6 +131,7 @@ export namespace Attributes {
     | IFloat
     | IInteger
     | IBoolean
+    | IAny
     | IUnion
     | INDArray
     | IDataUnion;

--- a/src/parsers/base.ts
+++ b/src/parsers/base.ts
@@ -1,23 +1,12 @@
+import { Signal, ISignal } from '@lumino/signaling';
 
-import {
-  Signal, ISignal
-} from '@lumino/signaling';
+import { IWidget, getWidgetRefs, Attributes } from '../core';
 
-import {
-  IWidget, getWidgetRefs, Attributes
-} from '../core';
+import { MSet } from '../setMethods';
 
-import {
-  MSet
-} from '../setMethods';
-
-
-
-export
-interface IParserConstructor {
+export interface IParserConstructor {
   new (filename: string): Parser;
 }
-
 
 /**
  * The base parser class.
@@ -32,15 +21,13 @@ interface IParserConstructor {
  *    that this does not entail that all consumers have finished
  *    processing *if they perform async processing*.
  */
-export
-abstract class Parser {
+export abstract class Parser {
   /**
    * Initialize the parser.
    *
    * @param input String input to the parser, typically a filename
    */
-  constructor(protected input: string) {
-  }
+  constructor(protected input: string) {}
 
   /**
    * Start generating widget definitions.
@@ -61,7 +48,9 @@ abstract class Parser {
    * @param {IWidget} data The widget definition to inspect
    * @returns {MSet<string>} A set of widget names referenced
    */
-  resolveInternalRefs(properties: Attributes.Properties | undefined): MSet<string> {
+  resolveInternalRefs(
+    properties: Attributes.Properties | undefined
+  ): MSet<string> {
     if (!properties) {
       return new MSet();
     }
@@ -93,7 +82,5 @@ abstract class Parser {
    */
   abstract readonly widgetNames: MSet<string>;
 
-
   protected _newWidget = new Signal<this, IWidget>(this);
 }
-

--- a/src/parsers/base.ts
+++ b/src/parsers/base.ts
@@ -1,7 +1,7 @@
 
 import {
   Signal, ISignal
-} from '@phosphor/signaling';
+} from '@lumino/signaling';
 
 import {
   IWidget, getWidgetRefs, Attributes

--- a/src/parsers/formatTypes.ts
+++ b/src/parsers/formatTypes.ts
@@ -1,35 +1,29 @@
-
-import {
-  Attributes
-} from '../core';
+import { Attributes } from '../core';
 
 /**
  * Interface of the JSON definition file root node.
  */
-export
-interface IDefinition {
+export interface IDefinition {
   widgets: {
     [key: string]: IWidgetJSON;
-  }
+  };
 }
 
 /**
  * A widget definition structure.
  */
-export
-interface IWidgetJSON {
+export interface IWidgetJSON {
   inherits?: string[];
   properties?: {
     [key: string]: AttributeDef;
-  },
+  };
   help?: string;
 }
 
 /**
  * Base structure for all attribute definitions.
  */
-export
-interface IBaseAttributeJSON {
+export interface IBaseAttributeJSON {
   help?: string;
   allowNull?: boolean;
 }
@@ -37,16 +31,14 @@ interface IBaseAttributeJSON {
 /**
  * Base structure for all typed attribute definitions.
  */
-export
-interface ITypedAttributeJSON extends IBaseAttributeJSON {
+export interface ITypedAttributeJSON extends IBaseAttributeJSON {
   type: string;
 }
 
 /**
  * Array/sequence attribute definition.
  */
-export
-interface IArrayAttributeJSON extends ITypedAttributeJSON {
+export interface IArrayAttributeJSON extends ITypedAttributeJSON {
   type: 'array';
   default?: any[] | null;
   items?: IAttributeJSON[] | IAttributeJSON;
@@ -55,8 +47,7 @@ interface IArrayAttributeJSON extends ITypedAttributeJSON {
 /**
  * Widget reference attribute definition.
  */
-export
-interface IWidgetRefAttributeJSON extends ITypedAttributeJSON {
+export interface IWidgetRefAttributeJSON extends ITypedAttributeJSON {
   type: 'widgetRef';
   widgetType: string | string[];
   default?: null;
@@ -65,8 +56,7 @@ interface IWidgetRefAttributeJSON extends ITypedAttributeJSON {
 /**
  * Object/hashmap/dictionary attribute definition.
  */
-export
-interface IObjectAttributeJSON extends ITypedAttributeJSON {
+export interface IObjectAttributeJSON extends ITypedAttributeJSON {
   type: 'object';
   default?: any | null;
 }
@@ -74,8 +64,7 @@ interface IObjectAttributeJSON extends ITypedAttributeJSON {
 /**
  * String attribute definition.
  */
-export
-interface IStringAttributeJSON extends ITypedAttributeJSON {
+export interface IStringAttributeJSON extends ITypedAttributeJSON {
   type: 'string';
   default?: string | null;
 }
@@ -83,8 +72,7 @@ interface IStringAttributeJSON extends ITypedAttributeJSON {
 /**
  * Floating point number attribute definition.
  */
-export
-interface IFloatAttributeJSON extends ITypedAttributeJSON {
+export interface IFloatAttributeJSON extends ITypedAttributeJSON {
   type: 'float';
   default?: number | null;
 }
@@ -92,8 +80,7 @@ interface IFloatAttributeJSON extends ITypedAttributeJSON {
 /**
  * Integer attribute definition.
  */
-export
-interface IIntegerAttributeJSON extends ITypedAttributeJSON {
+export interface IIntegerAttributeJSON extends ITypedAttributeJSON {
   type: 'int';
   default?: number | null;
 }
@@ -101,8 +88,7 @@ interface IIntegerAttributeJSON extends ITypedAttributeJSON {
 /**
  * Boolean attribute definition.
  */
-export
-interface IBooleanAttributeJSON extends ITypedAttributeJSON {
+export interface IBooleanAttributeJSON extends ITypedAttributeJSON {
   type: 'boolean';
   default?: boolean | null;
 }
@@ -110,12 +96,11 @@ interface IBooleanAttributeJSON extends ITypedAttributeJSON {
 /**
  * Numpy.ndarray-like attribute definition.
  */
-export
-interface INDArrayAttributeJSON extends ITypedAttributeJSON {
+export interface INDArrayAttributeJSON extends ITypedAttributeJSON {
   type: 'ndarray';
   default?: any[] | null;
   shape?: number[];
-  dtype: string;  // TODO: Make enum
+  dtype: string; // TODO: Make enum
 }
 
 /**
@@ -123,90 +108,111 @@ interface INDArrayAttributeJSON extends ITypedAttributeJSON {
  *
  * See jupyter-datawidgets for details.
  */
-export
-interface IDataUnionAttributeJSON extends ITypedAttributeJSON {
+export interface IDataUnionAttributeJSON extends ITypedAttributeJSON {
   type: 'dataunion';
   default?: any[] | null;
   shape?: number[];
-  dtype: string;  // TODO: Make enum
+  dtype: string; // TODO: Make enum
 }
 
 /**
  * Union attribute definition.
  */
-export
-interface IUnionAttributeJSON extends IBaseAttributeJSON {
+export interface IUnionAttributeJSON extends IBaseAttributeJSON {
   oneOf: NNAttributeDef[];
 }
 
 /**
  * An extended attribute definition.
  */
-export
-type IAttributeJSON = (
-  IArrayAttributeJSON | IObjectAttributeJSON | IWidgetRefAttributeJSON |
-  IStringAttributeJSON | IFloatAttributeJSON | IIntegerAttributeJSON |
-  IBooleanAttributeJSON | IUnionAttributeJSON | INDArrayAttributeJSON |
-  IDataUnionAttributeJSON
-);
+export type IAttributeJSON =
+  | IArrayAttributeJSON
+  | IObjectAttributeJSON
+  | IWidgetRefAttributeJSON
+  | IStringAttributeJSON
+  | IFloatAttributeJSON
+  | IIntegerAttributeJSON
+  | IBooleanAttributeJSON
+  | IUnionAttributeJSON
+  | INDArrayAttributeJSON
+  | IDataUnionAttributeJSON;
 
-export
-type NNAttributeDef = string | number | boolean | IAttributeJSON;
+export type NNAttributeDef = string | number | boolean | IAttributeJSON;
 
 /**
  * An attribute definition.
  */
-export
-type AttributeDef = NNAttributeDef | null | undefined;
+export type AttributeDef = NNAttributeDef | null | undefined;
 
-
-export
-type Properties = {[key: string]: AttributeDef};
+export type Properties = { [key: string]: AttributeDef };
 
 /**
  * Check whether the attribute defintion is for a union type.
  */
-export
-function isUnionAttribute(attribute: AttributeDef): attribute is IUnionAttributeJSON {
-  return !!attribute && typeof attribute === 'object' && 'oneOf' in attribute && attribute.oneOf !== undefined;
+export function isUnionAttribute(
+  attribute: AttributeDef
+): attribute is IUnionAttributeJSON {
+  return (
+    !!attribute &&
+    typeof attribute === 'object' &&
+    'oneOf' in attribute &&
+    attribute.oneOf !== undefined
+  );
 }
 
 /**
  * Check whether the attribute defintion is for a widget reference type.
  */
-export
-function isWidgetRef(data: AttributeDef): data is IWidgetRefAttributeJSON {
-  return !!data && typeof data === 'object' &&
-    !isUnionAttribute(data) && data.type === 'widgetRef';
+export function isWidgetRef(
+  data: AttributeDef
+): data is IWidgetRefAttributeJSON {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    !isUnionAttribute(data) &&
+    data.type === 'widgetRef'
+  );
 }
 
 /**
  * Check whether the attribute defintion is for an array/sequence type.
  */
-export
-function isArrayAttribute(data: AttributeDef): data is IArrayAttributeJSON {
-  return !!data && typeof data === 'object' &&
-    !isUnionAttribute(data) && data.type === 'array';
+export function isArrayAttribute(
+  data: AttributeDef
+): data is IArrayAttributeJSON {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    !isUnionAttribute(data) &&
+    data.type === 'array'
+  );
 }
 
 /**
  * Check whether the attribute defintion is for an ndarray type.
  */
-export
-function isNDArray(data: AttributeDef): data is INDArrayAttributeJSON {
-  return !!data && typeof data === 'object' &&
-    !isUnionAttribute(data) && data.type === 'ndarray';
+export function isNDArray(data: AttributeDef): data is INDArrayAttributeJSON {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    !isUnionAttribute(data) &&
+    data.type === 'ndarray'
+  );
 }
 
 /**
  * Check whether the attribute defintion is for an dataunion type.
  */
-export
-function isDataUnion(data: AttributeDef): data is IDataUnionAttributeJSON {
-  return !!data && typeof data === 'object' &&
-    !isUnionAttribute(data) && data.type === 'dataunion';
+export function isDataUnion(
+  data: AttributeDef
+): data is IDataUnionAttributeJSON {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    !isUnionAttribute(data) &&
+    data.type === 'dataunion'
+  );
 }
-
 
 /**
  * Translate an attribute definition from its form on disk, to the
@@ -215,31 +221,37 @@ function isDataUnion(data: AttributeDef): data is IDataUnionAttributeJSON {
  * @param attribute The attribute definition to translate.
  * @returns The translated attribute
  */
-export function translateToInternal(attribute: NNAttributeDef): Attributes.DefinedAttribute
-export function translateToInternal(attribute: null | undefined): undefined
-export function translateToInternal(attribute: AttributeDef): Attributes.Attribute
-export function translateToInternal(attribute: AttributeDef): Attributes.Attribute {
+export function translateToInternal(
+  attribute: NNAttributeDef
+): Attributes.DefinedAttribute;
+export function translateToInternal(attribute: null | undefined): undefined;
+export function translateToInternal(
+  attribute: AttributeDef
+): Attributes.Attribute;
+export function translateToInternal(
+  attribute: AttributeDef
+): Attributes.Attribute {
   if (typeof attribute === 'string') {
     return {
       type: 'string',
       default: attribute,
-    }
+    };
   } else if (typeof attribute === 'number') {
     if (Number.isInteger(attribute)) {
       return {
         type: 'int',
         default: attribute,
-      }
+      };
     }
     return {
       type: 'float',
       default: attribute,
-    }
+    };
   } else if (typeof attribute === 'boolean') {
     return {
       type: 'boolean',
       default: attribute,
-    }
+    };
   } else if (attribute === null) {
     throw new Error('Property is simply defined as "null", which is invalid');
   } else if (attribute === undefined) {
@@ -248,7 +260,7 @@ export function translateToInternal(attribute: AttributeDef): Attributes.Attribu
     return {
       type: 'union',
       oneOf: attribute.oneOf.map((a) => translateToInternal(a)),
-    }
+    };
   } else if (isArrayAttribute(attribute)) {
     let items: undefined | Attributes.DefinedAttribute[];
     if (attribute.items === undefined) {
@@ -261,20 +273,20 @@ export function translateToInternal(attribute: AttributeDef): Attributes.Attribu
     return {
       ...attribute,
       items,
-    }
+    };
   } else {
     return attribute;
   }
 }
 
-
-export
-function translatePropertiesToInternal(props: Properties | undefined): Attributes.Properties | undefined {
+export function translatePropertiesToInternal(
+  props: Properties | undefined
+): Attributes.Properties | undefined {
   if (!props) {
     return props;
   }
   return Object.keys(props).reduce((res, key) => {
     res[key] = translateToInternal(props[key]);
     return res;
-  }, {} as {[key: string]: Attributes.Attribute});
+  }, {} as { [key: string]: Attributes.Attribute });
 }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,4 +1,3 @@
-
 export * from './base';
 export * from './json';
 export * from './python';

--- a/src/parsers/json.ts
+++ b/src/parsers/json.ts
@@ -1,29 +1,17 @@
-
 import * as fs from 'fs-extra';
 
-import {
-  Parser
-} from './base';
+import { Parser } from './base';
 
-import {
-  IDefinition, translatePropertiesToInternal
-} from './formatTypes'
+import { IDefinition, translatePropertiesToInternal } from './formatTypes';
 
-import {
-  IWidget
-} from '../core';
+import { IWidget } from '../core';
 
-import {
-  MSet
-} from '../setMethods';
-
+import { MSet } from '../setMethods';
 
 /**
  * Parser for our custom JSON schema format.
  */
-export
-class JsonParser extends Parser {
-
+export class JsonParser extends Parser {
   start(): Promise<void> {
     return fs.readFile(this.input).then((f) => {
       this.processDefinition(JSON.parse(f.toString()) as IDefinition);
@@ -62,5 +50,3 @@ class JsonParser extends Parser {
 
   protected _names: MSet<string>;
 }
-
-

--- a/src/parsers/python.ts
+++ b/src/parsers/python.ts
@@ -1,41 +1,31 @@
-
 import * as path from 'path';
 
-import {
-  exec as execSync
-} from 'child_process';
+import { exec as execSync } from 'child_process';
 
-import {
-  promisify
-} from 'util';
+import { promisify } from 'util';
 
-import {
-  JsonParser
-} from './json';
+import { JsonParser } from './json';
 
-import {
-  IDefinition
-} from './formatTypes';
+import { IDefinition } from './formatTypes';
 
 const exec = promisify(execSync);
 
 // Path to python implementation of the parser
 const PYTHON_HELPER = path.resolve(__dirname, 'python_parser.py');
 
-
 /**
  * Parser for generating widgets from Widget definitions in python.
  */
-export
-class PythonParser extends JsonParser {
-
+export class PythonParser extends JsonParser {
   start(): Promise<void> {
     // This calls out to an implementation in python, that pipes back JSON
     // in our custom format, see JsonParser.
     const cmd = `python "${PYTHON_HELPER}" "${this.input}"`;
-    return exec(cmd, {windowsHide: true} as any).then(({stdout, stderr}) => {
-      const data = JSON.parse(stdout as any as string) as IDefinition;
-      return this.processDefinition(data);
-    });
+    return exec(cmd, { windowsHide: true } as any).then(
+      ({ stdout, stderr }) => {
+        const data = JSON.parse((stdout as any) as string) as IDefinition;
+        return this.processDefinition(data);
+      }
+    );
   }
 }

--- a/src/parsers/python_parser.py
+++ b/src/parsers/python_parser.py
@@ -1,4 +1,3 @@
-
 import argparse
 import inspect
 import importlib
@@ -14,7 +13,7 @@ import traitlets
 
 def _build_arg_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('input')
+    parser.add_argument("input")
     return parser
 
 
@@ -29,13 +28,15 @@ def main(args=None):
 
 def find_widgets(filename=None, module_name=None, package=None):
     if filename is not None:
-        spec = importlib.util.spec_from_file_location(module_name or '_widget_gen_import', filename)
+        spec = importlib.util.spec_from_file_location(
+            module_name or "_widget_gen_import", filename
+        )
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
     elif module_name is not None:
         mod = importlib.import_module(module_name, package=package)
     else:
-        raise ValueError('Either filename or module_name need to be passed!')
+        raise ValueError("Either filename or module_name need to be passed!")
 
     try:
         candidates = mod.__all__
@@ -44,8 +45,11 @@ def find_widgets(filename=None, module_name=None, package=None):
 
     for candidate_name in candidates:
         candidate = getattr(mod, candidate_name)
-        if (inspect.isclass(candidate) and issubclass(candidate, Widget) and 
-                candidate not in (Widget, DOMWidget)):
+        if (
+            inspect.isclass(candidate)
+            and issubclass(candidate, Widget)
+            and candidate not in (Widget, DOMWidget)
+        ):
             yield (candidate_name, candidate)
 
 
@@ -63,7 +67,7 @@ def convert(value):
     """Convert widget definitions to JSON-able object"""
     widget_definitions = {}
 
-    if (os.path.splitext(value)[1] == '.py'):
+    if os.path.splitext(value)[1] == ".py":
         for (name, cls) in find_widgets(filename=value):
             widget_definitions[name] = convertWidget(name, cls)
     else:
@@ -78,33 +82,33 @@ def convertWidget(name, cls):
     definition = {}
 
     if cls.__init__.__doc__:
-        definition['help'] = cls.__init__.__doc__
+        definition["help"] = cls.__init__.__doc__
     elif cls.__doc__:
-        definition['help'] = cls.__doc__
+        definition["help"] = cls.__doc__
 
     if cls.__bases__:
-        definition['inherits'] = [base.__name__ for base in cls.__bases__]
+        definition["inherits"] = [base.__name__ for base in cls.__bases__]
 
     properties = {}
     for name, trait in cls.class_own_traits(sync=True).items():
         properties[name] = convertTrait(trait)
     if properties:
-        definition['properties'] = properties
+        definition["properties"] = properties
 
     return definition
 
 
 trait_to_type = {
-    traitlets.Unicode: 'string',
-    traitlets.Bool: 'boolean',
-    traitlets.Int: 'int',
-    traitlets.Float: 'float',
-    traitlets.List: 'array',
-    traitlets.Tuple: 'array',
-    traitlets.Dict: 'object',
-    traitlets.Instance: 'widgetRef',
-    NDArray: 'ndarray',
-    DataUnion: 'dataunion',
+    traitlets.Unicode: "string",
+    traitlets.Bool: "boolean",
+    traitlets.Int: "int",
+    traitlets.Float: "float",
+    traitlets.List: "array",
+    traitlets.Tuple: "array",
+    traitlets.Dict: "object",
+    traitlets.Instance: "widgetRef",
+    NDArray: "ndarray",
+    DataUnion: "dataunion",
 }
 
 
@@ -118,9 +122,9 @@ def get_trait_default(trait):
 def convertTrait(trait):
     definition = {}
     if trait.allow_none is not traitlets.Undefined:
-        definition['allowNull'] = trait.allow_none
-    if trait.help not in (traitlets.Undefined, '', None):
-        definition['help'] = trait.help
+        definition["allowNull"] = trait.allow_none
+    if trait.help not in (traitlets.Undefined, "", None):
+        definition["help"] = trait.help
 
     default = get_trait_default(trait)
     if default is not trait.__class__.default_value:
@@ -128,29 +132,30 @@ def convertTrait(trait):
             # TODO: Extract shape and dtype constraints, and convert default value to list
             pass
         elif not isinstance(trait, traitlets.Union):
-            definition['default'] = default
+            definition["default"] = default
 
     for tt, type_name in trait_to_type.items():
         if isinstance(trait, tt):
-            definition['type'] = type_name
-            if type_name == 'array':
-                subtraits = getattr(trait, '_traits', None)
-                subtrait = getattr(trait, '_trait', None)
+            definition["type"] = type_name
+            if type_name == "array":
+                subtraits = getattr(trait, "_traits", None)
+                subtrait = getattr(trait, "_trait", None)
                 if subtraits not in (None, traitlets.Undefined):
-                    definition['items'] = [convertTrait(subtt) for subtt in subtraits]
+                    definition["items"] = [convertTrait(subtt) for subtt in subtraits]
                 elif subtrait:
-                    definition['items'] = convertTrait(subtrait)
-            if type_name == 'widgetRef':
+                    definition["items"] = convertTrait(subtrait)
+            if type_name == "widgetRef":
                 if inspect.isclass(trait.klass):
-                    definition['widgetType'] = trait.klass.__name__
+                    definition["widgetType"] = trait.klass.__name__
                 else:
-                    definition['widgetType'] = trait.klass
+                    definition["widgetType"] = trait.klass
             break
     else:
         if isinstance(trait, traitlets.Union):
-            definition['oneOf'] = [convertTrait(subtt) for subtt in trait.trait_types]
+            definition["oneOf"] = [convertTrait(subtt) for subtt in trait.trait_types]
 
     return definition
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/src/parsers/python_parser.py
+++ b/src/parsers/python_parser.py
@@ -107,6 +107,9 @@ trait_to_type = {
     traitlets.Tuple: "array",
     traitlets.Dict: "object",
     traitlets.Instance: "widgetRef",
+    traitlets.Enum: "any",
+    traitlets.CaselessStrEnum: "string",
+    traitlets.Any: "any",
     traitlets.Union: "union",
     NDArray: "ndarray",
     DataUnion: "dataunion",
@@ -118,6 +121,11 @@ def get_trait_default(trait):
         return trait.make_dynamic_default()
     else:
         return trait.default_value
+
+
+def get_enums(trait):
+    if isinstance(trait, (traitlets.Enum)):
+        return trait.values
 
 
 def convertTrait(trait):
@@ -134,6 +142,10 @@ def convertTrait(trait):
             pass
         elif not isinstance(trait, traitlets.Union):
             definition["default"] = default
+
+    enums = get_enums(trait)
+    if enums is not None:
+        definition["enum"] = enums
 
     for tt, type_name in trait_to_type.items():
         if isinstance(trait, tt):

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,14 +1,8 @@
-
 import * as path from 'path';
 
-import {
-  Parser, JsonParser, PythonParser
-} from './parsers';
+import { Parser, JsonParser, PythonParser } from './parsers';
 
-import {
-  writers, Writer
-} from './writers';
-
+import { writers, Writer } from './writers';
 
 function makeParser(filename: string, parserName?: string): Parser {
   if (parserName !== undefined) {
@@ -23,27 +17,32 @@ function makeParser(filename: string, parserName?: string): Parser {
     }
   }
   switch (path.extname(filename)) {
-  case '':
-  case '.json':
-    return new JsonParser(filename);
-  case '.py':
-    return new PythonParser(filename);
-  default:
-    throw new Error(`Unknown file extension for file: ${filename}`);
+    case '':
+    case '.json':
+      return new JsonParser(filename);
+    case '.py':
+      return new PythonParser(filename);
+    default:
+      throw new Error(`Unknown file extension for file: ${filename}`);
   }
 }
 
-export
-function run(filename: string, languages: string[], options: Partial<IOptions>) {
-  const {parserName, templateFile, fileExt} = options;
+export function run(
+  filename: string,
+  languages: string[],
+  options: Partial<IOptions>
+) {
+  const { parserName, templateFile, fileExt } = options;
   const output = options.output || '.';
   let parser = makeParser(filename, parserName);
   let instances: Writer[] = [];
   for (let language of languages) {
     let writerCtor = writers[language];
     if (writerCtor === undefined) {
-      throw new Error(`Unknown language: ${language}. ` +
-        `Valid languages: ${Object.keys(writers)}.`);
+      throw new Error(
+        `Unknown language: ${language}. ` +
+          `Valid languages: ${Object.keys(writers)}.`
+      );
     }
     let options: Writer.IOptions = {};
     if (templateFile) {
@@ -56,18 +55,21 @@ function run(filename: string, languages: string[], options: Partial<IOptions>) 
     instances.push(writer);
     parser.newWidget.connect(writer.onWidget, writer);
   }
-  return parser.start().then(() => {
-    return Promise.all(instances.map((writer) => {
-      return writer.finalize();
-    }));
-  }, (error) => {
-    console.log(error);
-  });
+  return parser.start().then(
+    () => {
+      return Promise.all(
+        instances.map((writer) => {
+          return writer.finalize();
+        })
+      );
+    },
+    (error) => {
+      console.log(error);
+    }
+  );
 }
 
-
-export
-interface IOptions {
+export interface IOptions {
   output: string;
   parserName: string;
   templateFile: string;

--- a/src/setMethods.ts
+++ b/src/setMethods.ts
@@ -1,30 +1,27 @@
-
-
-export
-class MSet<T> extends Set<T> {
-    union(setB: Set<T>|T[]) {
-        var union = new MSet(this);
-        for (var elem of setB) {
-            union.add(elem);
-        }
-        return union;
+export class MSet<T> extends Set<T> {
+  union(setB: Set<T> | T[]) {
+    var union = new MSet(this);
+    for (var elem of setB) {
+      union.add(elem);
     }
+    return union;
+  }
 
-    intersection(setB: Set<T>|T[]) {
-        var intersection = new MSet<T>();
-        for (var elem of setB) {
-            if (this.has(elem)) {
-                intersection.add(elem);
-            }
-        }
-        return intersection;
+  intersection(setB: Set<T> | T[]) {
+    var intersection = new MSet<T>();
+    for (var elem of setB) {
+      if (this.has(elem)) {
+        intersection.add(elem);
+      }
     }
+    return intersection;
+  }
 
-    difference(setB: Set<T>|T[]) {
-        var difference = new MSet(this);
-        for (var elem of setB) {
-            difference.delete(elem);
-        }
-        return difference;
+  difference(setB: Set<T> | T[]) {
+    var difference = new MSet(this);
+    for (var elem of setB) {
+      difference.delete(elem);
     }
+    return difference;
+  }
 }

--- a/src/writers/base.ts
+++ b/src/writers/base.ts
@@ -1,20 +1,13 @@
+import { Parser } from '../parsers';
 
-import {
-  Parser
-} from '../parsers';
-
-import {
-  IWidget
-} from '../core';
+import { IWidget } from '../core';
 
 import * as fs from 'fs-extra';
-
 
 /**
  * Interface definition for constructor
  */
-export
-interface IWriterConstructor {
+export interface IWriterConstructor {
   /**
    * Create a code writer.
    *
@@ -23,15 +16,13 @@ interface IWriterConstructor {
   new (output: string, options?: Writer.IOptions): Writer;
 }
 
-
 /**
  * Base class for all code writers.
  *
  * Defines a common constructor signature, and slots/hooks that
  * will be called at the appropriate times during processing.
  */
-export
-abstract class Writer {
+export abstract class Writer {
   /**
    * Create a code writer.
    *
@@ -39,7 +30,8 @@ abstract class Writer {
    */
   constructor(output: string, options?: Writer.IOptions) {
     this.output = output;
-    this.outputMultiple = fs.existsSync(output) && fs.statSync(output).isDirectory();
+    this.outputMultiple =
+      fs.existsSync(output) && fs.statSync(output).isDirectory();
   }
 
   /**
@@ -62,8 +54,7 @@ abstract class Writer {
    *
    * @memberof Writer
    */
-  finalize(): void {
-  };
+  finalize(): void {}
 
   /**
    * The output path to be used by the writer
@@ -84,11 +75,8 @@ abstract class Writer {
   protected firstWidget: boolean = true;
 }
 
-
-export
-namespace Writer {
-  export
-  interface IOptions {
+export namespace Writer {
+  export interface IOptions {
     [key: string]: string;
   }
 }

--- a/src/writers/index.ts
+++ b/src/writers/index.ts
@@ -1,28 +1,14 @@
+import { IWriterConstructor } from './base';
 
+import { PythonWriter } from './python';
 
-import {
-  IWriterConstructor
-} from './base';
+import { JavaWriter } from './java';
 
-import {
-  PythonWriter
-} from './python';
+import { JSES5Writer, JSES6Writer, TSWriter } from './js';
 
-import {
-  JavaWriter
-} from './java';
+export { Writer, IWriterConstructor } from './base';
 
-import {
-  JSES5Writer, JSES6Writer, TSWriter
-} from './js';
-
-
-export {
-  Writer, IWriterConstructor
-} from './base';
-
-export
-let writers: {[key: string]: IWriterConstructor| undefined} = {
+export let writers: { [key: string]: IWriterConstructor | undefined } = {
   python: PythonWriter,
   js: JSES5Writer,
   javascript: JSES5Writer,
@@ -32,4 +18,4 @@ let writers: {[key: string]: IWriterConstructor| undefined} = {
   es6: JSES6Writer,
   ts: TSWriter,
   java: JavaWriter,
-}
+};

--- a/src/writers/java.ts
+++ b/src/writers/java.ts
@@ -143,7 +143,7 @@ function formatDefault(data: Attributes.Attribute, recursive = false): string {
     res = convertValue(data);
   } else {
     // Atrtibute definition is a full specification object
-    if (Attributes.isUnion(data)) {
+    if (data.type === 'union') {
       // Use the default from the first possible union type:
       res = formatDefault(data.oneOf[0], true);
     } else {
@@ -205,7 +205,7 @@ function initializer(key: string, data: Attributes.Attribute): string | null {
 
   if (data !== undefined) {
     // Attribute definition is a full specification object
-    if (Attributes.isUnion(data)) {
+    if (data?.type === 'union') {
       // Use the default from the first possible union type:
       res = initializer(key, data.oneOf[0]);
     } else if (data.type === 'object') {

--- a/src/writers/java.ts
+++ b/src/writers/java.ts
@@ -1,20 +1,13 @@
-
 import * as path from 'path';
 
-import {
-  TemplateWriter, TemplateState
-} from './template';
+import { TemplateWriter, TemplateState } from './template';
 
-import {
-  Attributes, IWidget
-} from '../core';
-
+import { Attributes, IWidget } from '../core';
 
 /**
  * A writer for Java based widgets
  */
-export
-class JavaWriter extends TemplateWriter {
+export class JavaWriter extends TemplateWriter {
   /**
    * Create a Java writer
    */
@@ -36,7 +29,9 @@ class JavaWriter extends TemplateWriter {
    */
   write(filename: string, widgets: IWidget[]): void {
     if (widgets.length > 1 && !this.outputMultiple) {
-      throw new Error('Cannot write multiple widget definitions to one Java file!');
+      throw new Error(
+        'Cannot write multiple widget definitions to one Java file!'
+      );
     }
     return super.write(filename, widgets);
   }
@@ -45,36 +40,36 @@ class JavaWriter extends TemplateWriter {
     if (!attr) {
       return 'Object';
     }
-    switch(attr.type) {
-    case 'string': {
-      return 'String';
-    }
-    case 'boolean': {
-      return 'boolean';
-    }
-    case 'int': {
-      return 'int';
-    }
-    case 'float': {
-      return 'double';
-    }
-    case 'array': {
-      return 'List';
-    }
-    case 'object': {
-      return 'Map<String, Serializable>';
-    }
-    case 'widgetRef': {
-      if (Array.isArray(attr.widgetType)) {
-        // For widget refs that can be one of multiple types,
-        // use the known common base:
-        return 'Widget';
+    switch (attr.type) {
+      case 'string': {
+        return 'String';
       }
-      return attr.widgetType;
-    }
-    default: {
-      return 'Object';
-    }
+      case 'boolean': {
+        return 'boolean';
+      }
+      case 'int': {
+        return 'int';
+      }
+      case 'float': {
+        return 'double';
+      }
+      case 'array': {
+        return 'List';
+      }
+      case 'object': {
+        return 'Map<String, Serializable>';
+      }
+      case 'widgetRef': {
+        if (Array.isArray(attr.widgetType)) {
+          // For widget refs that can be one of multiple types,
+          // use the known common base:
+          return 'Widget';
+        }
+        return attr.widgetType;
+      }
+      default: {
+        return 'Object';
+      }
     }
   }
 
@@ -82,19 +77,21 @@ class JavaWriter extends TemplateWriter {
     data = super.transformState(data);
     data.package = '<placeholderPackageName>';
     data.widgets = data.widgets.map((widget) => {
-      let {properties} = widget;
+      let { properties } = widget;
       return {
         ...widget,
-        properties: properties ? Object.keys(properties).reduce((res, key) => {
-          let attr = properties![key];
-          res[key] = {
-            ...attr,
-            javatype: this.javatype(attr),
-            defaultValue: formatDefault(attr),
-            initializer: initializer(key, attr),
-          }
-          return res;
-        }, {} as TemplateState) : properties,
+        properties: properties
+          ? Object.keys(properties).reduce((res, key) => {
+              let attr = properties![key];
+              res[key] = {
+                ...attr,
+                javatype: this.javatype(attr),
+                defaultValue: formatDefault(attr),
+                initializer: initializer(key, attr),
+              };
+              return res;
+            }, {} as TemplateState)
+          : properties,
       };
     });
     return data;
@@ -105,21 +102,18 @@ class JavaWriter extends TemplateWriter {
   }
 }
 
-
 function camelCase(str: string) {
   let parsed_str = '';
-  const split = str.split("_");
+  const split = str.split('_');
   for (let word of split) {
     parsed_str += word.charAt(0).toUpperCase() + word.slice(1);
   }
   return parsed_str;
 }
 
-
 function fromLower(str: string) {
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
-
 
 function convertValue(value: any): string {
   if (value === true) {
@@ -131,85 +125,77 @@ function convertValue(value: any): string {
   } else if (value === undefined) {
     return 'null';
   } else if (Array.isArray(value)) {
-    return `${value.map(v => convertValue(v)).join(', ')}`;
+    return `${value.map((v) => convertValue(v)).join(', ')}`;
   } else if (typeof value === 'string') {
     return `"${value.toString()}"`;
   }
   return value.toString();
 }
 
-
 /**
  * Transform the default value.
  */
-function formatDefault(data: Attributes.Attribute, recursive=false): string {
+function formatDefault(data: Attributes.Attribute, recursive = false): string {
   let res: string;
 
-  if (data === undefined ) {
-
+  if (data === undefined) {
     // Attribute definition is in simplified form
     res = convertValue(data);
-
   } else {
     // Atrtibute definition is a full specification object
     if (Attributes.isUnion(data)) {
-
       // Use the default from the first possible union type:
       res = formatDefault(data.oneOf[0], true);
-
     } else {
-
       switch (data.type) {
-
-      case 'object':
-        if (data.default === null || data.default === undefined) {
-          res = 'null';
-        } else {
-          res = 'new HashMap<String, Serializable>()';
-        }
-        break;
-
-      case 'array':
-        let items = data.items;
-        if (items === undefined) {
-          res = `new ArrayList<>()`;
-        } else if (Array.isArray(items)) {
-          if (data.default !== undefined) {
-            res = (`Arrays.asList(${convertValue(data.default)})`);
+        case 'object':
+          if (data.default === null || data.default === undefined) {
+            res = 'null';
           } else {
-            res = `new ArrayList<>()`;
+            res = 'new HashMap<String, Serializable>()';
           }
-        } else {
-          res = `Arrays.asList(${formatDefault(items, true)}))`
-        }
-        break;
+          break;
 
-      case 'widgetRef':
-        if (data.default === null || data.default === undefined) {
-          res = 'null';
-        } else {
-          res = `new ${data.widgetType}()`;
-        }
-        break;
+        case 'array':
+          let items = data.items;
+          if (items === undefined) {
+            res = `new ArrayList<>()`;
+          } else if (Array.isArray(items)) {
+            if (data.default !== undefined) {
+              res = `Arrays.asList(${convertValue(data.default)})`;
+            } else {
+              res = `new ArrayList<>()`;
+            }
+          } else {
+            res = `Arrays.asList(${formatDefault(items, true)}))`;
+          }
+          break;
 
-      case 'ndarray':
-        // TODO: Make a Java package for ipydatawidgets
-        res = `null`;
-        break;
+        case 'widgetRef':
+          if (data.default === null || data.default === undefined) {
+            res = 'null';
+          } else {
+            res = `new ${data.widgetType}()`;
+          }
+          break;
 
-      case 'dataunion':
-      // TODO: Make a Java package for ipydatawidgets
-        res = `null`;
-        break;
+        case 'ndarray':
+          // TODO: Make a Java package for ipydatawidgets
+          res = `null`;
+          break;
 
-      default:
-        res = convertValue(data.default);
+        case 'dataunion':
+          // TODO: Make a Java package for ipydatawidgets
+          res = `null`;
+          break;
+
+        default:
+          res = convertValue(data.default);
       }
     }
   }
   return res;
 }
-
 
 /**
  * Create an initializer block, or return null if no block is needed.
@@ -217,27 +203,28 @@ function formatDefault(data: Attributes.Attribute, recursive=false): string {
 function initializer(key: string, data: Attributes.Attribute): string | null {
   let res: string | null = null;
 
-  if (data !== undefined ) {
-
+  if (data !== undefined) {
     // Attribute definition is a full specification object
     if (Attributes.isUnion(data)) {
-
       // Use the default from the first possible union type:
       res = initializer(key, data.oneOf[0]);
-
     } else if (data.type === 'object') {
-        if (data.default !== null && data.default !== undefined) {
-          // This should also get an initializer if there is a default value!
-          const keys = Object.keys(data.default);
-          if (keys.length > 0) {
-            const lines = ['{'];
-            for (let dkey of keys) {
-              lines.push(`    ${fromLower(camelCase(key))}.put("${dkey}", ${formatDefault(data.default[dkey])});`);
-            }
-            lines.push('  }');
-            res = lines.join('\n');
+      if (data.default !== null && data.default !== undefined) {
+        // This should also get an initializer if there is a default value!
+        const keys = Object.keys(data.default);
+        if (keys.length > 0) {
+          const lines = ['{'];
+          for (let dkey of keys) {
+            lines.push(
+              `    ${fromLower(camelCase(key))}.put("${dkey}", ${formatDefault(
+                data.default[dkey]
+              )});`
+            );
           }
+          lines.push('  }');
+          res = lines.join('\n');
         }
+      }
     }
   }
   return res;

--- a/src/writers/js/base.ts
+++ b/src/writers/js/base.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 
 import { TemplateWriter, TemplateState } from '../template';
 
-import { hasWidgetRef, Attributes } from '../../core';
+import { hasWidgetRef } from '../../core';
 
 import { getDefaultValue } from './utils';
 
@@ -30,9 +30,9 @@ export class BaseJSWriter extends TemplateWriter {
       const serializers: { [key: string]: string } = {};
       if (properties) {
         for (let key of Object.keys(properties)) {
-          if (Attributes.isDataUnion(properties[key])) {
+          if (properties[key]?.type === 'union') {
             serializers[key] = 'data_union_serialization';
-          } else if (Attributes.isNDArray(properties[key])) {
+          } else if (properties[key]?.type === 'ndarray') {
             serializers[key] = 'array_serialization';
           } else if (hasWidgetRef(properties[key])) {
             serializers[key] = '{ deserialize: unpack_models }';

--- a/src/writers/js/base.ts
+++ b/src/writers/js/base.ts
@@ -1,24 +1,15 @@
-
 import * as path from 'path';
 
-import {
-  TemplateWriter, TemplateState
-} from '../template';
+import { TemplateWriter, TemplateState } from '../template';
 
-import {
-  hasWidgetRef, Attributes
-} from '../../core';
+import { hasWidgetRef, Attributes } from '../../core';
 
-import {
-  getDefaultValue
-} from './utils';
-
+import { getDefaultValue } from './utils';
 
 /**
  * Javascript ES6 code writer.
  */
-export
-class BaseJSWriter extends TemplateWriter {
+export class BaseJSWriter extends TemplateWriter {
   constructor(output: string, options: BaseJSWriter.IOptions) {
     super(output, {
       fileExt: 'js',
@@ -29,12 +20,14 @@ class BaseJSWriter extends TemplateWriter {
   transformState(data: TemplateState): TemplateState {
     data = super.transformState(data);
     data.widgets = data.widgets.map((widget) => {
-      let {inherits, properties} = widget;
+      let { inherits, properties } = widget;
       if (inherits.length > 1) {
-        console.warn(`Cannot use multiple inheritance for ${name} with JS.` +
-          `Dropping ancestors: ${inherits.slice(1)}`);
+        console.warn(
+          `Cannot use multiple inheritance for ${name} with JS.` +
+            `Dropping ancestors: ${inherits.slice(1)}`
+        );
       }
-      const serializers: {[key: string]: string} = {};
+      const serializers: { [key: string]: string } = {};
       if (properties) {
         for (let key of Object.keys(properties)) {
           if (Attributes.isDataUnion(properties[key])) {
@@ -48,14 +41,16 @@ class BaseJSWriter extends TemplateWriter {
       }
       return {
         ...widget,
-        properties: properties ? Object.keys(properties).reduce((res, key) => {
-          let attr = properties![key];
-          res[key] = {
-            ...attr,
-            default: getDefaultValue(attr),
-          }
-          return res;
-        }, {} as TemplateState) : properties,
+        properties: properties
+          ? Object.keys(properties).reduce((res, key) => {
+              let attr = properties![key];
+              res[key] = {
+                ...attr,
+                default: getDefaultValue(attr),
+              };
+              return res;
+            }, {} as TemplateState)
+          : properties,
         inherits: inherits.slice(0, 1),
         serializers,
       };
@@ -68,12 +63,8 @@ class BaseJSWriter extends TemplateWriter {
   }
 }
 
-
-export
-namespace BaseJSWriter {
-
-  export
-  interface IOptions extends Partial<TemplateWriter.IOptions> {
+export namespace BaseJSWriter {
+  export interface IOptions extends Partial<TemplateWriter.IOptions> {
     template: string;
   }
 }

--- a/src/writers/js/index.ts
+++ b/src/writers/js/index.ts
@@ -1,4 +1,3 @@
-
 export * from './js-es5';
 export * from './js-es6';
 export * from './ts';

--- a/src/writers/js/js-es5.ts
+++ b/src/writers/js/js-es5.ts
@@ -1,16 +1,10 @@
-
-
 import * as fs from 'fs-extra';
 
 import * as path from 'path';
 
-import {
-  BaseJSWriter
-} from './base';
-
+import { BaseJSWriter } from './base';
 
 const INDENT = '  ';
-
 
 /**
  * Javascript ES5 code writer.
@@ -18,9 +12,7 @@ const INDENT = '  ';
  * Will generate ES5 code, but will have a dependency on underscore
  * for utility functions.
  */
-export
-class JSES5Writer extends BaseJSWriter {
-
+export class JSES5Writer extends BaseJSWriter {
   constructor(output: string, options: Partial<BaseJSWriter.IOptions> = {}) {
     super(output, {
       template: path.resolve(__dirname, '../../../templates/js-es5.njk'),
@@ -32,7 +24,7 @@ class JSES5Writer extends BaseJSWriter {
    * Called when all widgets are parsed. Writes index.js if appropriate.
    */
   finalize(): Promise<void> {
-    return super.finalize().then(() =>{
+    return super.finalize().then(() => {
       if (this.outputMultiple) {
         // Write init file for directory output
         let fname = path.join(this.output, `index.js`);

--- a/src/writers/js/js-es6.ts
+++ b/src/writers/js/js-es6.ts
@@ -1,19 +1,13 @@
-
-
 import * as fs from 'fs-extra';
 
 import * as path from 'path';
 
-import {
-  BaseJSWriter
-} from './base';
-
+import { BaseJSWriter } from './base';
 
 /**
  * Javascript ES6 code writer.
  */
-export
-class JSES6Writer extends BaseJSWriter {
+export class JSES6Writer extends BaseJSWriter {
   constructor(output: string, options: Partial<BaseJSWriter.IOptions> = {}) {
     super(output, {
       template: path.resolve(__dirname, '../../../templates/js-es6.njk'),
@@ -25,14 +19,14 @@ class JSES6Writer extends BaseJSWriter {
    * Called when all widgets are parsed. Writes index.js if appropriate.
    */
   finalize(): Promise<void> {
-    return super.finalize().then(() =>{
+    return super.finalize().then(() => {
       if (this.outputMultiple) {
         // Write init file for directory output
         let fname = this.filenameForIndex();
         let lines = this.modules.map((name) => {
           return `export { ${name}Model } from './${name}';`;
         });
-        lines.push('');  // add an empty line at end
+        lines.push(''); // add an empty line at end
         return fs.writeFile(fname, lines.join('\n'));
       }
     });

--- a/src/writers/js/ts.ts
+++ b/src/writers/js/ts.ts
@@ -1,23 +1,15 @@
-
 import * as path from 'path';
 
-import {
-  JSES6Writer
-} from './js-es6';
+import { JSES6Writer } from './js-es6';
 
-import {
-  BaseJSWriter
-} from './base';
-
-
+import { BaseJSWriter } from './base';
 
 /**
  * Write typescript code.
  *
  * Extends the ES6 writer as TS is a superset of ES6.
  */
-export
-class TSWriter extends JSES6Writer {
+export class TSWriter extends JSES6Writer {
   constructor(output: string, options: Partial<BaseJSWriter.IOptions> = {}) {
     super(output, {
       template: path.resolve(__dirname, '../../../templates/ts.njk'),

--- a/src/writers/js/utils.ts
+++ b/src/writers/js/utils.ts
@@ -21,7 +21,7 @@ export function getDefaultValue(data: Attributes.Attribute): string {
     typeof data === 'string'
   ) {
     return formatValue(data);
-  } else if (Attributes.isUnion(data)) {
+  } else if (data.type === 'union') {
     return getDefaultValue(data.oneOf[0]);
   }
   // JSON object

--- a/src/writers/js/utils.ts
+++ b/src/writers/js/utils.ts
@@ -1,8 +1,4 @@
-
-import {
-  Attributes
-} from '../../core';
-
+import { Attributes } from '../../core';
 
 function formatValue(value: any): string {
   if (value === undefined) {
@@ -16,11 +12,14 @@ function formatValue(value: any): string {
  *
  * @param data The attribute whose default value to use
  */
-export
-function getDefaultValue(data: Attributes.Attribute): string {
-  if (data === null || data === undefined ||
-      typeof data === 'number' || typeof data === 'boolean' ||
-      typeof data === 'string') {
+export function getDefaultValue(data: Attributes.Attribute): string {
+  if (
+    data === null ||
+    data === undefined ||
+    typeof data === 'number' ||
+    typeof data === 'boolean' ||
+    typeof data === 'string'
+  ) {
     return formatValue(data);
   } else if (Attributes.isUnion(data)) {
     return getDefaultValue(data.oneOf[0]);

--- a/src/writers/python.ts
+++ b/src/writers/python.ts
@@ -1,23 +1,14 @@
-
-
 import * as fs from 'fs-extra';
 
 import * as path from 'path';
 
-import {
-  TemplateWriter, TemplateState
-} from './template';
+import { TemplateWriter, TemplateState } from './template';
 
-import {
-  Attributes, hasWidgetRef,
-} from '../core';
-
+import { Attributes, hasWidgetRef } from '../core';
 
 const INDENT = '    ';
 
-
-export
-class PythonWriter extends TemplateWriter {
+export class PythonWriter extends TemplateWriter {
   /**
    *
    */
@@ -32,31 +23,33 @@ class PythonWriter extends TemplateWriter {
   transformState(data: TemplateState): TemplateState {
     data = super.transformState(data);
     data.widgets = data.widgets.map((widget) => {
-      let {properties} = widget;
+      let { properties } = widget;
       return {
         ...widget,
-        properties: properties ? Object.keys(properties).reduce((res, key) => {
-          let attr = properties![key];
-          res[key] = {
-            ...attr,
-            traitDef: this.makeTrait(attr),
-          }
-          return res;
-        }, {} as TemplateState) : properties,
+        properties: properties
+          ? Object.keys(properties).reduce((res, key) => {
+              let attr = properties![key];
+              res[key] = {
+                ...attr,
+                traitDef: this.makeTrait(attr),
+              };
+              return res;
+            }, {} as TemplateState)
+          : properties,
       };
     });
     return data;
   }
 
   finalize(): Promise<void> {
-    return super.finalize().then(() =>{
+    return super.finalize().then(() => {
       if (this.outputMultiple) {
         // Write init file for directory output
         let fname = path.join(this.output, `__init__.py`);
         let lines = this.modules.map((name) => {
           return `from .${name} import ${name}`;
         });
-        lines.push('');  // add an empty line at end
+        lines.push(''); // add an empty line at end
         return fs.writeFile(fname, lines.join('\n'));
       }
     });
@@ -72,7 +65,7 @@ class PythonWriter extends TemplateWriter {
     } else if (value === undefined) {
       return '';
     } else if (Array.isArray(value)) {
-      return `[${value.map(v => this.convertValue(v)).join(', ')}]`;
+      return `[${value.map((v) => this.convertValue(v)).join(', ')}]`;
     } else if (typeof value === 'string') {
       return `'${value.toString()}'`;
     } else if (typeof value === 'object') {
@@ -82,136 +75,139 @@ class PythonWriter extends TemplateWriter {
     return value.toString();
   }
 
-  protected makeTrait(data: Attributes.Attribute, innerTrait=false): string {
+  protected makeTrait(data: Attributes.Attribute, innerTrait = false): string {
     let traitDef: string;
-    let tag = '.tag(sync=True)'
+    let tag = '.tag(sync=True)';
 
     if (data === undefined) {
-
       traitDef = 'Any(Undefined)';
-
     } else {
-
       // JSON object
       if (data.help) {
-        tag = `.tag(sync=True, help='${data.help}')`
+        tag = `.tag(sync=True, help='${data.help}')`;
       }
       let allowNoneArg = '';
       if (data.allowNull !== undefined && data.allowNull !== false) {
         allowNoneArg = `, allow_none=${this.convertValue(data.allowNull)}`;
       }
       if (Attributes.isUnion(data)) {
-
         const defs = data.oneOf.map((subdata) => this.makeTrait(subdata, true));
-        traitDef = `Union([\n${INDENT}${INDENT}${defs.join(`,\n${INDENT}${INDENT}`)}\n${INDENT}]${allowNoneArg})`;
-
+        traitDef = `Union([\n${INDENT}${INDENT}${defs.join(
+          `,\n${INDENT}${INDENT}`
+        )}\n${INDENT}]${allowNoneArg})`;
       } else {
-
         let defValue = this.convertValue(data.default);
         switch (data.type) {
+          case 'int':
+            traitDef = `Int(${defValue}${allowNoneArg})`;
+            break;
 
-        case 'int':
-          traitDef = `Int(${defValue}${allowNoneArg})`;
-          break;
+          case 'float':
+            traitDef = `Float(${defValue}${allowNoneArg})`;
+            break;
 
-        case 'float':
-          traitDef = `Float(${defValue}${allowNoneArg})`;
-          break;
+          case 'boolean':
+            traitDef = `Bool(${defValue}${allowNoneArg})`;
+            break;
 
-        case 'boolean':
-          traitDef = `Bool(${defValue}${allowNoneArg})`;
-          break;
+          case 'string':
+            traitDef = `Unicode(${defValue}${allowNoneArg})`;
+            break;
 
-        case 'string':
-          traitDef = `Unicode(${defValue}${allowNoneArg})`;
-          break;
-
-        case 'object':
-          let defArg;
-          if (data.default === undefined) {
-            defArg = '';
-            // Remove ', ' from start of allowNoneArg
-            allowNoneArg = allowNoneArg.slice(2);
-          } else {
-            defArg = `default_value=${defValue}`;
-          }
-          traitDef = `Dict(${defArg}${allowNoneArg})`;
-          break;
-
-        case 'array':
-          let items = data.items;
-          if (items === undefined) {
-            traitDef = `Tuple(${defValue}${allowNoneArg})`;
-          } else if (Array.isArray(items)) {
-            let lines = [];
-            for (let item of items) {
-              lines.push(this.makeTrait(item, true));
+          case 'object':
+            let defArg;
+            if (data.default === undefined) {
+              defArg = '';
+              // Remove ', ' from start of allowNoneArg
+              allowNoneArg = allowNoneArg.slice(2);
+            } else {
+              defArg = `default_value=${defValue}`;
             }
-            if (defValue) {
-              lines.push(`default_value=${defValue}`)
+            traitDef = `Dict(${defArg}${allowNoneArg})`;
+            break;
+
+          case 'array':
+            let items = data.items;
+            if (items === undefined) {
+              traitDef = `Tuple(${defValue}${allowNoneArg})`;
+            } else if (Array.isArray(items)) {
+              let lines = [];
+              for (let item of items) {
+                lines.push(this.makeTrait(item, true));
+              }
+              if (defValue) {
+                lines.push(`default_value=${defValue}`);
+              }
+              if (allowNoneArg) {
+                lines.push(allowNoneArg.slice(2));
+              }
+              traitDef =
+                `Tuple(\n` +
+                `${INDENT}${INDENT}${lines.join(`,\n${INDENT}${INDENT}`)}\n` +
+                `${INDENT})`;
+            } else {
+              traitDef = `List(${this.makeTrait(items, true)}${
+                defValue ? `, default_value=${defValue}` : ''
+              }${allowNoneArg})`;
             }
-            if (allowNoneArg) {
-              lines.push(allowNoneArg.slice(2));
+            break;
+
+          case 'widgetRef':
+            let type = data.widgetType;
+            if (Array.isArray(type)) {
+              const instances = type.map(function (typeName) {
+                return `${INDENT}${INDENT}Instance(${typeName})`;
+              });
+              traitDef =
+                'Union([\n' +
+                instances.join(',\n') +
+                `\n${INDENT}]${allowNoneArg})`;
+            } else {
+              traitDef = `Instance(${type}${allowNoneArg})`;
             }
-            traitDef = (
-              `Tuple(\n` +
-              `${INDENT}${INDENT}${lines.join(`,\n${INDENT}${INDENT}`)}\n` +
-              `${INDENT})`
-            );
-          } else {
-            traitDef = `List(${this.makeTrait(items, true)}${defValue ? `, default_value=${defValue}` : ''}${allowNoneArg})`
-          }
-          break;
+            break;
 
-        case 'widgetRef':
-          let type = data.widgetType;
-          if (Array.isArray(type)) {
-            const instances = type.map(function(typeName) {
-              return `${INDENT}${INDENT}Instance(${typeName})`;
-            });
-            traitDef = 'Union([\n' + instances.join(',\n') + `\n${INDENT}]${allowNoneArg})`;
-          } else {
-            traitDef = `Instance(${type}${allowNoneArg})`;
-          }
-          break;
+          case 'ndarray':
+            var { shape, dtype } = data;
+            let dtypeStr = '',
+              shapeStr = '';
+            if (dtype) {
+              dtypeStr = `dtype=${dtype}`;
+            }
+            if (shape) {
+              let pyShape = shape.map((entry) => {
+                return entry === null ? 'None' : entry;
+              });
+              shapeStr = `.valid(shape_constraints(${pyShape.join(', ')}))`;
+            }
+            traitDef = `NDArray(${dtypeStr}${allowNoneArg})${shapeStr}`;
+            tag = tag.slice(0, tag.length - 1) + ', **array_serialization)';
+            break;
 
-        case 'ndarray':
-          var {shape, dtype} = data;
-          let dtypeStr = '', shapeStr = '';
-          if (dtype) {
-            dtypeStr = `dtype=${dtype}`;
-          }
-          if (shape) {
-            let pyShape = shape.map((entry) => {
-              return entry === null ? 'None' : entry;
-            });
-            shapeStr = `.valid(shape_constraints(${pyShape.join(', ')}))`;
-          }
-          traitDef = `NDArray(${dtypeStr}${allowNoneArg})${shapeStr}`;
-          tag = tag.slice(0, tag.length - 1) + ', **array_serialization)';
-          break;
+          case 'dataunion':
+            var { shape, dtype } = data;
+            let parts = [];
+            if (defValue !== '') {
+              parts.push(`${defValue}`);
+            }
+            if (dtype) {
+              parts.push(`dtype=${dtype}`);
+            }
+            if (shape) {
+              let pyShape = shape.map((entry) => {
+                return entry === null ? 'None' : entry;
+              });
+              parts.push(
+                `shape_constraint=shape_constraints(${pyShape.join(', ')}))`
+              );
+            }
+            traitDef = `DataUnion(${parts.join(', ')}${allowNoneArg})`;
+            tag =
+              tag.slice(0, tag.length - 1) + ', **data_union_serialization)';
+            break;
 
-        case 'dataunion':
-          var {shape, dtype} = data;
-          let parts = [];
-          if (defValue !== '') {
-            parts.push(`${defValue}`);
-          }
-          if (dtype) {
-            parts.push(`dtype=${dtype}`);
-          }
-          if (shape) {
-            let pyShape = shape.map((entry) => {
-              return entry === null ? 'None' : entry;
-            });
-            parts.push(`shape_constraint=shape_constraints(${pyShape.join(', ')}))`);
-          }
-          traitDef = `DataUnion(${parts.join(', ')}${allowNoneArg})`;
-          tag = tag.slice(0, tag.length - 1) + ', **data_union_serialization)';
-          break;
-
-        default:
-          throw new Error(`Unknown type: ${(data as any).type}`);
+          default:
+            throw new Error(`Unknown type: ${(data as any).type}`);
         }
       }
     }
@@ -223,7 +219,3 @@ class PythonWriter extends TemplateWriter {
     return traitDef + tag;
   }
 }
-
-
-
-

--- a/src/writers/python.ts
+++ b/src/writers/python.ts
@@ -75,6 +75,9 @@ class PythonWriter extends TemplateWriter {
       return `[${value.map(v => this.convertValue(v)).join(', ')}]`;
     } else if (typeof value === 'string') {
       return `'${value.toString()}'`;
+    } else if (typeof value === 'object') {
+      // Assume this is a Dict trait, inline as JSON string
+      return `json.loads('${JSON.stringify(value)}')`;
     }
     return value.toString();
   }

--- a/src/writers/python.ts
+++ b/src/writers/python.ts
@@ -95,9 +95,33 @@ export class PythonWriter extends TemplateWriter {
         traitDef = `Union([\n${INDENT}${INDENT}${defs.join(
           `,\n${INDENT}${INDENT}`
         )}\n${INDENT}]${allowNoneArg})`;
+      } else if (data?.enum) {
+        // TODO: Figure out a way to combine enum validation with normal traits
+        // (probably make our own trait types via mixins)
+        let values = [
+          `[`,
+          ...data.enum.map((v) => `${INDENT}${this.convertValue(v)},`),
+          `]`,
+        ].join(`\n${INDENT}${INDENT}`);
+        let entries = [values];
+        let defValue = this.convertValue(data.default);
+        if (defValue !== '') {
+          entries.push(`default_value=${defValue}`);
+        }
+        if (allowNoneArg) {
+          entries.push(allowNoneArg.slice(2));
+        }
+        traitDef =
+          'Enum(' +
+          `\n${INDENT}${INDENT}${entries.join(`,\n${INDENT}${INDENT}`)}\n` +
+          `${INDENT})`;
       } else {
         let defValue = this.convertValue(data.default);
         switch (data.type) {
+          case 'any':
+            traitDef = `Any(${defValue}${allowNoneArg})`;
+            break;
+
           case 'int':
             traitDef = `Int(${defValue}${allowNoneArg})`;
             break;

--- a/src/writers/python.ts
+++ b/src/writers/python.ts
@@ -39,7 +39,7 @@ class PythonWriter extends TemplateWriter {
           let attr = properties![key];
           res[key] = {
             ...attr,
-            traitDef: makeTrait(attr),
+            traitDef: this.makeTrait(attr),
           }
           return res;
         }, {} as TemplateState) : properties,
@@ -61,165 +61,166 @@ class PythonWriter extends TemplateWriter {
       }
     });
   }
-}
 
-
-
-function convertValue(value: any): string {
-  if (value === true) {
-    return 'True';
-  } else if (value === false) {
-    return 'False';
-  } else if (value === null) {
-    return 'None';
-  } else if (value === undefined) {
-    return '';
-  } else if (Array.isArray(value)) {
-    return `[${value.map(v => convertValue(v)).join(', ')}]`;
-  } else if (typeof value === 'string') {
-    return `'${value.toString()}'`;
+  protected convertValue(value: any): string {
+    if (value === true) {
+      return 'True';
+    } else if (value === false) {
+      return 'False';
+    } else if (value === null) {
+      return 'None';
+    } else if (value === undefined) {
+      return '';
+    } else if (Array.isArray(value)) {
+      return `[${value.map(v => this.convertValue(v)).join(', ')}]`;
+    } else if (typeof value === 'string') {
+      return `'${value.toString()}'`;
+    }
+    return value.toString();
   }
-  return value.toString();
-}
 
+  protected makeTrait(data: Attributes.Attribute, innerTrait=false): string {
+    let traitDef: string;
+    let tag = '.tag(sync=True)'
 
-function makeTrait(data: Attributes.Attribute, innerTrait=false): string {
-  let traitDef: string;
-  let tag = '.tag(sync=True)'
+    if (data === undefined) {
 
-  if (data === undefined) {
-
-    traitDef = 'Any(Undefined)';
-
-  } else {
-
-    // JSON object
-    if (data.help) {
-      tag = `.tag(sync=True, help='${data.help}')`
-    }
-    let allowNoneArg = '';
-    if (data.allowNull !== undefined && data.allowNull !== false) {
-      allowNoneArg = `, allow_none=${convertValue(data.allowNull)}`;
-    }
-    if (Attributes.isUnion(data)) {
-
-      const defs = data.oneOf.map((subdata) => makeTrait(subdata, true));
-      traitDef = `Union([\n${INDENT}${INDENT}${defs.join(`,\n${INDENT}${INDENT}`)}\n${INDENT}]${allowNoneArg})`;
+      traitDef = 'Any(Undefined)';
 
     } else {
 
-      let defValue = convertValue(data.default);
-      switch (data.type) {
+      // JSON object
+      if (data.help) {
+        tag = `.tag(sync=True, help='${data.help}')`
+      }
+      let allowNoneArg = '';
+      if (data.allowNull !== undefined && data.allowNull !== false) {
+        allowNoneArg = `, allow_none=${this.convertValue(data.allowNull)}`;
+      }
+      if (Attributes.isUnion(data)) {
 
-      case 'int':
-        traitDef = `Int(${defValue}${allowNoneArg})`;
-        break;
+        const defs = data.oneOf.map((subdata) => this.makeTrait(subdata, true));
+        traitDef = `Union([\n${INDENT}${INDENT}${defs.join(`,\n${INDENT}${INDENT}`)}\n${INDENT}]${allowNoneArg})`;
 
-      case 'float':
-        traitDef = `Float(${defValue}${allowNoneArg})`;
-        break;
+      } else {
 
-      case 'boolean':
-        traitDef = `Bool(${defValue}${allowNoneArg})`;
-        break;
+        let defValue = this.convertValue(data.default);
+        switch (data.type) {
 
-      case 'string':
-        traitDef = `Unicode(${defValue}${allowNoneArg})`;
-        break;
+        case 'int':
+          traitDef = `Int(${defValue}${allowNoneArg})`;
+          break;
 
-      case 'object':
-        let defArg;
-        if (data.default === undefined) {
-          defArg = '';
-          // Remove ', ' from start of allowNoneArg
-          allowNoneArg = allowNoneArg.slice(2);
-        } else {
-          defArg = `default_value=${defValue}`;
-        }
-        traitDef = `Dict(${defArg}${allowNoneArg})`;
-        break;
+        case 'float':
+          traitDef = `Float(${defValue}${allowNoneArg})`;
+          break;
 
-      case 'array':
-        let items = data.items;
-        if (items === undefined) {
-          traitDef = `Tuple(${defValue}${allowNoneArg})`;
-        } else if (Array.isArray(items)) {
-          let lines = [];
-          for (let item of items) {
-            lines.push(makeTrait(item, true));
+        case 'boolean':
+          traitDef = `Bool(${defValue}${allowNoneArg})`;
+          break;
+
+        case 'string':
+          traitDef = `Unicode(${defValue}${allowNoneArg})`;
+          break;
+
+        case 'object':
+          let defArg;
+          if (data.default === undefined) {
+            defArg = '';
+            // Remove ', ' from start of allowNoneArg
+            allowNoneArg = allowNoneArg.slice(2);
+          } else {
+            defArg = `default_value=${defValue}`;
           }
-          if (defValue) {
-            lines.push(`default_value=${defValue}`)
+          traitDef = `Dict(${defArg}${allowNoneArg})`;
+          break;
+
+        case 'array':
+          let items = data.items;
+          if (items === undefined) {
+            traitDef = `Tuple(${defValue}${allowNoneArg})`;
+          } else if (Array.isArray(items)) {
+            let lines = [];
+            for (let item of items) {
+              lines.push(this.makeTrait(item, true));
+            }
+            if (defValue) {
+              lines.push(`default_value=${defValue}`)
+            }
+            if (allowNoneArg) {
+              lines.push(allowNoneArg.slice(2));
+            }
+            traitDef = (
+              `Tuple(\n` +
+              `${INDENT}${INDENT}${lines.join(`,\n${INDENT}${INDENT}`)}\n` +
+              `${INDENT})`
+            );
+          } else {
+            traitDef = `List(${this.makeTrait(items, true)}${defValue ? `, default_value=${defValue}` : ''}${allowNoneArg})`
           }
-          if (allowNoneArg) {
-            lines.push(allowNoneArg.slice(2));
+          break;
+
+        case 'widgetRef':
+          let type = data.widgetType;
+          if (Array.isArray(type)) {
+            const instances = type.map(function(typeName) {
+              return `${INDENT}${INDENT}Instance(${typeName})`;
+            });
+            traitDef = 'Union([\n' + instances.join(',\n') + `\n${INDENT}]${allowNoneArg})`;
+          } else {
+            traitDef = `Instance(${type}${allowNoneArg})`;
           }
-          traitDef = (
-            `Tuple(\n` +
-            `${INDENT}${INDENT}${lines.join(`,\n${INDENT}${INDENT}`)}\n` +
-            `${INDENT})`
-          );
-        } else {
-          traitDef = `List(${makeTrait(items, true)}${defValue ? `, default_value=${defValue}` : ''}${allowNoneArg})`
-        }
-        break;
+          break;
 
-      case 'widgetRef':
-        let type = data.widgetType;
-        if (Array.isArray(type)) {
-          const instances = type.map(function(typeName) {
-            return `${INDENT}${INDENT}Instance(${typeName})`;
-          });
-          traitDef = 'Union([\n' + instances.join(',\n') + `\n${INDENT}]${allowNoneArg})`;
-        } else {
-          traitDef = `Instance(${type}${allowNoneArg})`;
-        }
-        break;
+        case 'ndarray':
+          var {shape, dtype} = data;
+          let dtypeStr = '', shapeStr = '';
+          if (dtype) {
+            dtypeStr = `dtype=${dtype}`;
+          }
+          if (shape) {
+            let pyShape = shape.map((entry) => {
+              return entry === null ? 'None' : entry;
+            });
+            shapeStr = `.valid(shape_constraints(${pyShape.join(', ')}))`;
+          }
+          traitDef = `NDArray(${dtypeStr}${allowNoneArg})${shapeStr}`;
+          tag = tag.slice(0, tag.length - 1) + ', **array_serialization)';
+          break;
 
-      case 'ndarray':
-        var {shape, dtype} = data;
-        let dtypeStr = '', shapeStr = '';
-        if (dtype) {
-          dtypeStr = `dtype=${dtype}`;
-        }
-        if (shape) {
-          let pyShape = shape.map((entry) => {
-            return entry === null ? 'None' : entry;
-          });
-          shapeStr = `.valid(shape_constraints(${pyShape.join(', ')}))`;
-        }
-        traitDef = `NDArray(${dtypeStr}${allowNoneArg})${shapeStr}`;
-        tag = tag.slice(0, tag.length - 1) + ', **array_serialization)';
-        break;
+        case 'dataunion':
+          var {shape, dtype} = data;
+          let parts = [];
+          if (defValue !== '') {
+            parts.push(`${defValue}`);
+          }
+          if (dtype) {
+            parts.push(`dtype=${dtype}`);
+          }
+          if (shape) {
+            let pyShape = shape.map((entry) => {
+              return entry === null ? 'None' : entry;
+            });
+            parts.push(`shape_constraint=shape_constraints(${pyShape.join(', ')}))`);
+          }
+          traitDef = `DataUnion(${parts.join(', ')}${allowNoneArg})`;
+          tag = tag.slice(0, tag.length - 1) + ', **data_union_serialization)';
+          break;
 
-      case 'dataunion':
-        var {shape, dtype} = data;
-        let parts = [];
-        if (defValue !== '') {
-          parts.push(`${defValue}`);
+        default:
+          throw new Error(`Unknown type: ${(data as any).type}`);
         }
-        if (dtype) {
-          parts.push(`dtype=${dtype}`);
-        }
-        if (shape) {
-          let pyShape = shape.map((entry) => {
-            return entry === null ? 'None' : entry;
-          });
-          parts.push(`shape_constraint=shape_constraints(${pyShape.join(', ')}))`);
-        }
-        traitDef = `DataUnion(${parts.join(', ')}${allowNoneArg})`;
-        tag = tag.slice(0, tag.length - 1) + ', **data_union_serialization)';
-        break;
-
-      default:
-        throw new Error(`Unknown type: ${(data as any).type}`);
       }
     }
+    if (innerTrait) {
+      return traitDef;
+    } else if (hasWidgetRef(data)) {
+      tag = tag.slice(0, tag.length - 1) + ', **widget_serialization)';
+    }
+    return traitDef + tag;
   }
-  if (innerTrait) {
-    return traitDef;
-  } else if (hasWidgetRef(data)) {
-    tag = tag.slice(0, tag.length - 1) + ', **widget_serialization)';
-  }
-  return traitDef + tag;
 }
+
+
+
+

--- a/src/writers/python.ts
+++ b/src/writers/python.ts
@@ -90,7 +90,7 @@ export class PythonWriter extends TemplateWriter {
       if (data.allowNull !== undefined && data.allowNull !== false) {
         allowNoneArg = `, allow_none=${this.convertValue(data.allowNull)}`;
       }
-      if (Attributes.isUnion(data)) {
+      if (data.type === 'union') {
         const defs = data.oneOf.map((subdata) => this.makeTrait(subdata, true));
         traitDef = `Union([\n${INDENT}${INDENT}${defs.join(
           `,\n${INDENT}${INDENT}`

--- a/src/writers/template.ts
+++ b/src/writers/template.ts
@@ -1,40 +1,26 @@
-
-
 import * as fs from 'fs-extra';
 
 import * as path from 'path';
 
-import {
-  compile, Template, configure, Environment
-} from 'nunjucks';
+import { compile, Template, configure, Environment } from 'nunjucks';
 
-import {
-  Writer
-} from './base';
+import { Writer } from './base';
 
-import {
-  Parser
-} from '../parsers';
+import { Parser } from '../parsers';
 
-import {
-  IWidget
-} from '../core';
-
+import { IWidget } from '../core';
 
 const NUNJUCKS_ENV = configure(path.resolve(__dirname, '../../templates'), {
   autoescape: false,
   throwOnUndefined: true,
   trimBlocks: true,
   lstripBlocks: true,
-})
+});
 
-
-export
-type TemplateState = {
-  widgets: ReadonlyArray<IWidget>,
-  [key: string]: any,
-}
-
+export type TemplateState = {
+  widgets: ReadonlyArray<IWidget>;
+  [key: string]: any;
+};
 
 /**
  * Base class for template based writers.
@@ -49,8 +35,7 @@ type TemplateState = {
  * @class TemplateWriter
  * @extends {Writer}
  */
-export
-class TemplateWriter extends Writer {
+export class TemplateWriter extends Writer {
   /**
    *
    */
@@ -104,8 +89,8 @@ class TemplateWriter extends Writer {
    * @param {IWidget} widget The widget definition
    */
   onWidget(sender: Parser, data: IWidget): void {
-    let {name} = data;
-    data = {...data};
+    let { name } = data;
+    data = { ...data };
 
     if (this.outputMultiple) {
       this._modules.push(name);
@@ -153,7 +138,10 @@ class TemplateWriter extends Writer {
       if (!this.templateFile) {
         throw new Error('No template file set!');
       }
-      this._template = TemplateWriter.compileTemplate(this.templateFile, this.env);
+      this._template = TemplateWriter.compileTemplate(
+        this.templateFile,
+        this.env
+      );
     }
     return this._template;
   }
@@ -191,7 +179,7 @@ class TemplateWriter extends Writer {
 
   /**
    * The envionment config for the template engine.
-   * 
+   *
    * @protected
    * @type {Environment}
    */
@@ -209,13 +197,10 @@ class TemplateWriter extends Writer {
   private _state: IWidget[] = [];
 }
 
-
-export
-namespace TemplateWriter {
-  export
-  interface IOptions extends Writer.IOptions {
-      template: string;
-      fileExt: string;
+export namespace TemplateWriter {
+  export interface IOptions extends Writer.IOptions {
+    template: string;
+    fileExt: string;
   }
 
   /**
@@ -223,10 +208,12 @@ namespace TemplateWriter {
    *
    * @param templatePath The path to the template file.
    */
-  export
-  function compileTemplate(templatePath: string, env: Environment) {
-    return compile(fs.readFileSync(templatePath, {
-      encoding: 'utf-8'
-    }), env);
+  export function compileTemplate(templatePath: string, env: Environment) {
+    return compile(
+      fs.readFileSync(templatePath, {
+        encoding: 'utf-8',
+      }),
+      env
+    );
   }
 }

--- a/templates/python.njk
+++ b/templates/python.njk
@@ -2,6 +2,8 @@
 {% endblock %}
 {% block imports %}
 {% block globalimports %}
+import json
+
 from traitlets import (
     Unicode, Enum, Instance, Union, Float, Int, List, Tuple, Dict,
     Undefined, Bool, Any

--- a/templates/python.njk
+++ b/templates/python.njk
@@ -6,7 +6,7 @@ from traitlets import (
     Unicode, Enum, Instance, Union, Float, Int, List, Tuple, Dict,
     Undefined, Bool, Any
 )
-from ipywidgets import Widget, DOMWidget
+from ipywidgets import Widget, DOMWidget, register, widget_serialization
 from ipydatawidgets import (
     NDArray, DataUnion, shape_constraints, array_serialization,
     data_union_serialization
@@ -26,6 +26,7 @@ from .{{ ref }} import {{ ref }}
 {% block widget %}
 
 
+@register
 class {{ widget.name }}({{ widget.inherits | join(", ") }}):
 
 {% block widgetbody %}

--- a/test/definitions/test1.json
+++ b/test/definitions/test1.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "widgets": {
 
     "VtkWidget": {

--- a/test/definitions/test2.py
+++ b/test/definitions/test2.py
@@ -21,7 +21,7 @@ class A(Widget):
     string = Unicode(None, allow_none=True).tag(sync=True)
     boolean = Bool(True).tag(sync=True)
     list = List(Int(), [1, 2, 3]).tag(sync=True)
-    tuple = Tuple(Int(), Unicode(), CFloat(), default_value=(3, "foo", "4.5")).tag(
+    tuple = Tuple(Int(), Unicode(), CFloat(), default_value=(3, "foo", 4.5)).tag(
         sync=True
     )
     dict = Dict().tag(sync=True)
@@ -33,7 +33,7 @@ class A(Widget):
 class B(A):
     _model_name = Unicode("B").tag(sync=True)
 
-    ref = Instance(A).tag(sync=True, **widget_serialization)
+    ref = Instance(A, allow_none=True).tag(sync=True, **widget_serialization)
 
 
 __all__ = ["A", "B"]

--- a/test/definitions/test2.py
+++ b/test/definitions/test2.py
@@ -1,5 +1,6 @@
 from ipywidgets import DOMWidget, Widget, widget_serialization
 from traitlets import (
+    Any,
     Bool,
     CFloat,
     Dict,
@@ -26,6 +27,9 @@ class A(Widget):
     )
     dict = Dict().tag(sync=True)
     ddict = Dict(default_value={"foo": "bar"}).tag(sync=True)
+    enum = Enum(("foo", "bar"), default_value="bar").tag(sync=True)
+    enum_none = Enum(("foo", "bar"), default_value=None, allow_none=True).tag(sync=True)
+    any = Any(42).tag(sync=True)
 
     not_synced = Unicode()
 

--- a/test/definitions/test2.py
+++ b/test/definitions/test2.py
@@ -1,17 +1,16 @@
-from ipywidgets import Widget, DOMWidget, widget_serialization
-
+from ipywidgets import DOMWidget, Widget, widget_serialization
 from traitlets import (
-    Unicode,
+    Bool,
+    CFloat,
+    Dict,
+    Enum,
     Instance,
-    Union,
+    Int,
     List,
     Tuple,
-    Dict,
-    Int,
-    CFloat,
-    Bool,
     Undefined,
-    Enum,
+    Unicode,
+    Union,
 )
 
 

--- a/test/definitions/test2.py
+++ b/test/definitions/test2.py
@@ -1,27 +1,40 @@
-
 from ipywidgets import Widget, DOMWidget, widget_serialization
 
-from traitlets import Unicode, Instance, Union, List, Tuple, Dict, Int, CFloat, Bool, Undefined
+from traitlets import (
+    Unicode,
+    Instance,
+    Union,
+    List,
+    Tuple,
+    Dict,
+    Int,
+    CFloat,
+    Bool,
+    Undefined,
+    Enum,
+)
 
 
 class A(Widget):
-    _model_name = Unicode('A').tag(sync=True)
-    _model_module = Unicode('test2').tag(sync=True)
+    _model_name = Unicode("A").tag(sync=True)
+    _model_module = Unicode("test2").tag(sync=True)
 
     string = Unicode(None, allow_none=True).tag(sync=True)
     boolean = Bool(True).tag(sync=True)
     list = List(Int(), [1, 2, 3]).tag(sync=True)
-    tuple = Tuple(Int(), Unicode(), CFloat(), default_value=(3, 'foo', '4.5')).tag(sync=True)
+    tuple = Tuple(Int(), Unicode(), CFloat(), default_value=(3, "foo", "4.5")).tag(
+        sync=True
+    )
     dict = Dict().tag(sync=True)
-    ddict = Dict(default_value={'foo': 'bar'}).tag(sync=True)
+    ddict = Dict(default_value={"foo": "bar"}).tag(sync=True)
 
     not_synced = Unicode()
 
 
 class B(A):
-    _model_name = Unicode('B').tag(sync=True)
+    _model_name = Unicode("B").tag(sync=True)
 
     ref = Instance(A).tag(sync=True, **widget_serialization)
 
 
-__all__ = ['A', 'B']
+__all__ = ["A", "B"]

--- a/test/definitions/test_enum.json
+++ b/test/definitions/test_enum.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "widgets": {
+
+    "BaseTestWidget": {
+      "model_module_name": "test-widget",
+      "view_module_name": "test-widget",
+      "model_module_version": "1.0.0",
+      "model_view_version": {
+        "type": "string",
+        "default": null,
+        "allowNull": true
+      }
+    },
+
+    "EnumNullDefault": {
+      "inherits": ["BaseTestWidget"],
+      "properties": {
+        "_model_name": "EnumNullDefault",
+        "value": {
+          "type": "string",
+          "default": null,
+          "allowNull": true,
+          "enum": ["foo", "bar"]
+        }
+      }
+    },
+
+    "EnumExplicitDefault": {
+      "inherits": ["BaseTestWidget"],
+      "properties": {
+        "_model_name": "EnumExplicitDefault",
+        "value": {
+          "type": "string",
+          "default": "bar",
+          "allowNull": false,
+          "enum": ["foo", "bar"]
+        }
+      }
+    },
+
+    "EnumImplicitNullDefault": {
+      "inherits": ["BaseTestWidget"],
+      "properties": {
+        "_model_name": "EnumImplicitNullDefault",
+        "value": {
+          "type": "string",
+          "allowNull": true,
+          "enum": ["foo", "bar"]
+        }
+      }
+    }
+  }
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---timeout 10000
---require source-map-support/register
---recursive

--- a/test/test1.js
+++ b/test/test1.js
@@ -1,4 +1,3 @@
-
 require('source-map-support').install();
 
 const run = require('../lib/run').run;
@@ -14,258 +13,255 @@ const os = require('os');
 const expect = require('chai').expect;
 
 function mkdtemp(prefix) {
-  return fs.mkdtemp(path.join(
-    os.tmpdir(),
-    prefix
-  ));
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
 describe('test1', () => {
-
   describe('python', () => {
-
     it('should generate all the files', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test1.json');
       let outdir = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        return run(fname, ['python'], {output: outdir});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "DataArray.py",
-              "DataContainer.py",
-              "DataSet.py",
-              "ImageData.py",
-              "Piece.py",
-              "UnstructuredGrid.py",
-              "VtkWidget.py",
-              "__init__.py",
-            ]);
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            });
-          }
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['python'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'DataArray.py',
+                'DataContainer.py',
+                'DataSet.py',
+                'ImageData.py',
+                'Piece.py',
+                'UnstructuredGrid.py',
+                'VtkWidget.py',
+                '__init__.py',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
   });
-
 
   describe('javascript', () => {
-
     it('should generate all the files', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test1.json');
       let outdir = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        return run(fname, ['javascript'], {output: outdir});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "DataArray.js",
-              "DataContainer.js",
-              "DataSet.js",
-              "ImageData.js",
-              "Piece.js",
-              "UnstructuredGrid.js",
-              "VtkWidget.js",
-              "index.js",
-            ]);
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            });
-          }
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['javascript'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'DataArray.js',
+                'DataContainer.js',
+                'DataSet.js',
+                'ImageData.js',
+                'Piece.js',
+                'UnstructuredGrid.js',
+                'VtkWidget.js',
+                'index.js',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
 
     it('should generate a single file with all the definitions', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test1.json');
       let outdir = null;
       let outfile = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        outfile = path.join(outdir, 'widgets.js');
-        return run(fname, ['javascript'], {output: outfile});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "widgets.js",
-            ]);
-            const content = fs.readFileSync(outfile, {encoding: 'utf-8'});
-            const pattern = /^var (\w(\w|[_0-9])*)Model = (\w(\w|[_0-9])*)Model.extend\({$/gm;
-            const names = [];
-            let match;
-            while (match = pattern.exec(content)) {
-              names.push(match[1]);
-            }
-            expect(names.sort()).to.eql([
-              "DataArray",
-              "DataContainer",
-              "DataSet",
-              "ImageData",
-              "Piece",
-              "UnstructuredGrid",
-              "VtkWidget",
-            ])
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          outfile = path.join(outdir, 'widgets.js');
+          return run(fname, ['javascript'], { output: outfile });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql(['widgets.js']);
+              const content = fs.readFileSync(outfile, { encoding: 'utf-8' });
+              const pattern = /^var (\w(\w|[_0-9])*)Model = (\w(\w|[_0-9])*)Model.extend\({$/gm;
+              const names = [];
+              let match;
+              while ((match = pattern.exec(content))) {
+                names.push(match[1]);
               }
-            });
-          }
+              expect(names.sort()).to.eql([
+                'DataArray',
+                'DataContainer',
+                'DataSet',
+                'ImageData',
+                'Piece',
+                'UnstructuredGrid',
+                'VtkWidget',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
   });
-
 
   describe('ts', () => {
-
     it('should generate all the files', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test1.json');
       let outdir = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        return run(fname, ['ts'], {output: outdir});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "DataArray.ts",
-              "DataContainer.ts",
-              "DataSet.ts",
-              "ImageData.ts",
-              "Piece.ts",
-              "UnstructuredGrid.ts",
-              "VtkWidget.ts",
-              "index.ts",
-            ]);
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            });
-          }
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['ts'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'DataArray.ts',
+                'DataContainer.ts',
+                'DataSet.ts',
+                'ImageData.ts',
+                'Piece.ts',
+                'UnstructuredGrid.ts',
+                'VtkWidget.ts',
+                'index.ts',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
 
     it('should generate a single file with all the definitions', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test1.json');
       let outdir = null;
       let outfile = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        outfile = path.join(outdir, 'widgets.ts');
-        return run(fname, ['ts'], {output: outfile});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "widgets.ts",
-            ]);
-            const content = fs.readFileSync(outfile, {encoding: 'utf-8'});
-            const pattern = /^class (\w(\w|[_0-9])*?)Model extends (\w(\w|[_0-9])*?)Model \{$/gm;
-            const names = [];
-            let match;
-            while (match = pattern.exec(content)) {
-              names.push(match[1]);
-            }
-            expect(names.sort()).to.eql([
-              "DataArray",
-              "DataContainer",
-              "DataSet",
-              "ImageData",
-              "Piece",
-              "UnstructuredGrid",
-              "VtkWidget",
-            ])
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          outfile = path.join(outdir, 'widgets.ts');
+          return run(fname, ['ts'], { output: outfile });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql(['widgets.ts']);
+              const content = fs.readFileSync(outfile, { encoding: 'utf-8' });
+              const pattern = /^class (\w(\w|[_0-9])*?)Model extends (\w(\w|[_0-9])*?)Model \{$/gm;
+              const names = [];
+              let match;
+              while ((match = pattern.exec(content))) {
+                names.push(match[1]);
               }
-            });
-          }
+              expect(names.sort()).to.eql([
+                'DataArray',
+                'DataContainer',
+                'DataSet',
+                'ImageData',
+                'Piece',
+                'UnstructuredGrid',
+                'VtkWidget',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
   });
 
-
   describe('java', () => {
-
     it('should generate all the files', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test1.json');
       let outdir = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        return run(fname, ['java'], {output: outdir});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "DataArray.java",
-              "DataContainer.java",
-              "DataSet.java",
-              "ImageData.java",
-              "Piece.java",
-              "UnstructuredGrid.java",
-              "VtkWidget.java",
-            ]);
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            });
-          }
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['java'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'DataArray.java',
+                'DataContainer.java',
+                'DataSet.java',
+                'ImageData.java',
+                'Piece.java',
+                'UnstructuredGrid.java',
+                'VtkWidget.java',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
 
     it('should fail when trying to write to a single file', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test1.json');
@@ -277,23 +273,24 @@ describe('test1', () => {
         console.log = origConsole;
         rimraf(outdir, () => {});
       };
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        outfile = path.join(outdir, 'widgets.java');
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          outfile = path.join(outdir, 'widgets.java');
 
-        console.log = (message) => { log.push(message); };
-        return run(fname, ['java'], {output: outfile});
-      }).then(() => {
-        cleanUp();
-        expect(log.length).to.equal(1);
-        expect(log[0]).is.instanceOf(Error);
-        expect(log[0].message).to.eql(
-          'Cannot write multiple widget definitions to one Java file!');
-      }, cleanUp);
+          console.log = (message) => {
+            log.push(message);
+          };
+          return run(fname, ['java'], { output: outfile });
+        })
+        .then(() => {
+          cleanUp();
+          expect(log.length).to.equal(1);
+          expect(log[0]).is.instanceOf(Error);
+          expect(log[0].message).to.eql(
+            'Cannot write multiple widget definitions to one Java file!'
+          );
+        }, cleanUp);
     });
-
   });
-
-
-
 });

--- a/test/test2.js
+++ b/test/test2.js
@@ -8,38 +8,9 @@ const path = require('path');
 
 const fs = require('fs-extra');
 
-const os = require('os');
-
 const expect = require('chai').expect;
 
-const spawnSync = require('child_process').spawnSync;
-
-function mkdtemp(prefix) {
-  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
-}
-
-/**
- * Test that modules can be imported, and widgets instantiated
- */
-function instantiatePythonWidgets(outdir) {
-  const cmd = [
-    `MODULE_PATH = ${JSON.stringify(path.join(outdir, '__init__.py'))}`,
-    `MODULE_NAME = 'module_under_test'`,
-    `import importlib`,
-    `import sys`,
-    `spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)`,
-    `module = importlib.util.module_from_spec(spec)`,
-    `sys.modules[spec.name] = module`,
-    `spec.loader.exec_module(module)`,
-    `for w in dir(module):`,
-    `    if not w.startswith('_'):`,
-    `        getattr(module, w)()`,
-  ];
-  const res = spawnSync('python', ['-c', cmd.join('\n')], { encoding: 'utf8' });
-  if (res.status !== 0) {
-    throw new Error(res.stderr);
-  }
-}
+const { mkdtemp, instantiatePythonWidgets } = require('./util');
 
 describe('test2', () => {
   describe('python', () => {

--- a/test/test2.js
+++ b/test/test2.js
@@ -1,4 +1,3 @@
-
 require('source-map-support').install();
 
 const run = require('../lib/run').run;
@@ -14,121 +13,107 @@ const os = require('os');
 const expect = require('chai').expect;
 
 function mkdtemp(prefix) {
-  return fs.mkdtemp(path.join(
-    os.tmpdir(),
-    prefix
-  ));
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
-describe('test2', () => {
 
+describe('test2', () => {
   describe('python', () => {
 
     it('should generate all the files', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test2.py');
       let outdir = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        return run(fname, ['python'], {output: outdir});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "A.py",
-              "B.py",
-              '__init__.py',
-            ]);
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            });
-          }
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['python'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql(['A.py', 'B.py', '__init__.py']);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
   });
 
-
   describe('javascript', () => {
-
     it('should generate all the files', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test2.py');
       let outdir = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        return run(fname, ['javascript'], {output: outdir});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "A.js",
-              "B.js",
-              'index.js',
-            ]);
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
-              }
-            });
-          }
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['javascript'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql(['A.js', 'B.js', 'index.js']);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
 
     it('should generate a single file with all the definitions', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test2.py');
       let outdir = null;
       let outfile = null;
-      return mkdtemp('widget-gen').then((d) => {
-        outdir = d;
-        outfile = path.join(outdir, 'widgets.js');
-        return run(fname, ['javascript'], {output: outfile});
-      }).then(() => {
-        return fs.readdir(outdir);
-      }).then((dirFiles) => {
-        return new Promise((resolve, reject) => {
-          try {
-            expect(dirFiles).to.eql([
-              "widgets.js",
-            ]);
-            const content = fs.readFileSync(outfile, {encoding: 'utf-8'});
-            const pattern = /^var (\w(\w|[_0-9])*)Model = (\w(\w|[_0-9])*)Model.extend\({$/gm;
-            const names = [];
-            let match;
-            while (match = pattern.exec(content)) {
-              names.push(match[1]);
-            }
-            expect(names.sort()).to.eql([
-              "A",
-              "B",
-            ])
-          } finally {
-            rimraf(outdir, (error) => {
-              if (error) {
-                reject(error);
-              } else {
-                resolve();
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          outfile = path.join(outdir, 'widgets.js');
+          return run(fname, ['javascript'], { output: outfile });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql(['widgets.js']);
+              const content = fs.readFileSync(outfile, { encoding: 'utf-8' });
+              const pattern = /^var (\w(\w|[_0-9])*)Model = (\w(\w|[_0-9])*)Model.extend\({$/gm;
+              const names = [];
+              let match;
+              while ((match = pattern.exec(content))) {
+                names.push(match[1]);
               }
-            });
-          }
+              expect(names.sort()).to.eql(['A', 'B']);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
         });
-      });
     });
-
   });
-
-
 });

--- a/test/test2.js
+++ b/test/test2.js
@@ -12,14 +12,37 @@ const os = require('os');
 
 const expect = require('chai').expect;
 
+const spawnSync = require('child_process').spawnSync;
+
 function mkdtemp(prefix) {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
+/**
+ * Test that modules can be imported, and widgets instantiated
+ */
+function instantiatePythonWidgets(outdir) {
+  const cmd = [
+    `MODULE_PATH = ${JSON.stringify(path.join(outdir, '__init__.py'))}`,
+    `MODULE_NAME = 'module_under_test'`,
+    `import importlib`,
+    `import sys`,
+    `spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)`,
+    `module = importlib.util.module_from_spec(spec)`,
+    `sys.modules[spec.name] = module`,
+    `spec.loader.exec_module(module)`,
+    `for w in dir(module):`,
+    `    if not w.startswith('_'):`,
+    `        getattr(module, w)()`,
+  ];
+  const res = spawnSync('python', ['-c', cmd.join('\n')], { encoding: 'utf8' });
+  if (res.status !== 0) {
+    throw new Error(res.stderr);
+  }
+}
 
 describe('test2', () => {
   describe('python', () => {
-
     it('should generate all the files', () => {
       let fname = path.resolve(__dirname, 'definitions', 'test2.py');
       let outdir = null;
@@ -35,6 +58,7 @@ describe('test2', () => {
           return new Promise((resolve, reject) => {
             try {
               expect(dirFiles).to.eql(['A.py', 'B.py', '__init__.py']);
+              instantiatePythonWidgets(outdir);
             } finally {
               rimraf(outdir, (error) => {
                 if (error) {

--- a/test/test_custom_template.js
+++ b/test/test_custom_template.js
@@ -1,4 +1,3 @@
-
 require('source-map-support').install();
 
 const run = require('../lib/run').run;
@@ -14,53 +13,49 @@ const os = require('os');
 const expect = require('chai').expect;
 
 function mkdtemp(prefix) {
-  return fs.mkdtemp(path.join(
-    os.tmpdir(),
-    prefix
-  ));
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
 describe('custom template', () => {
-
   it('should generate all the files', () => {
     let fname = path.resolve(__dirname, 'definitions', 'test2.py');
     let tname = path.resolve(__dirname, 'custom_template.njk');
     let outdir = null;
-    return mkdtemp('widget-gen').then((d) => {
-      outdir = d;
-      return run(fname, ['ts'], {
-        output: outdir,
-        templateFile: tname,
+    return mkdtemp('widget-gen')
+      .then((d) => {
+        outdir = d;
+        return run(fname, ['ts'], {
+          output: outdir,
+          templateFile: tname,
+        });
+      })
+      .then(() => {
+        return fs.readdir(outdir);
+      })
+      .then((dirFiles) => {
+        return new Promise((resolve, reject) => {
+          try {
+            expect(dirFiles).to.eql(['A.ts', 'B.ts', 'index.ts']);
+            const pattern = /^ {4}this\.foo = 42;$/m;
+            dirFiles.forEach((fn) => {
+              if (fn === 'index.ts') {
+                return;
+              }
+              const content = fs.readFileSync(path.join(outdir, fn), {
+                encoding: 'utf-8',
+              });
+              expect(pattern.test(content), `file: ${fn}`).to.eql(true);
+            });
+          } finally {
+            rimraf(outdir, (error) => {
+              if (error) {
+                reject(error);
+              } else {
+                resolve();
+              }
+            });
+          }
+        });
       });
-    }).then(() => {
-      return fs.readdir(outdir);
-    }).then((dirFiles) => {
-      return new Promise((resolve, reject) => {
-        try {
-          expect(dirFiles).to.eql([
-            "A.ts",
-            "B.ts",
-            'index.ts',
-          ]);
-          const pattern = /^    this\.foo = 42;$/m;
-          dirFiles.forEach((fn) => {
-            if (fn === 'index.ts') {
-              return;
-            }
-            const content = fs.readFileSync(path.join(outdir, fn), {encoding: 'utf-8'});
-            expect(pattern.test(content), `file: ${fn}`).to.eql(true);
-          });
-        } finally {
-          rimraf(outdir, (error) => {
-            if (error) {
-              reject(error);
-            } else {
-              resolve();
-            }
-          });
-        }
-      });
-    });
   });
-
 });

--- a/test/test_definitions.js
+++ b/test/test_definitions.js
@@ -1,4 +1,3 @@
-
 require('source-map-support').install();
 
 const path = require('path');
@@ -14,28 +13,24 @@ const definitionSchema = fs.readFileSync(
   'utf-8'
 );
 
-
 describe('validate test definitions', () => {
   let dirname = path.resolve(__dirname, 'definitions');
 
   fs.readdirSync(dirname).forEach((fname) => {
-
     if (path.extname === '.json') {
-
       it(`should validate ${fname}`, () => {
-
-        return fs.readFile(path.join(dirname, fname), 'utf-8').then((content) => {
-          const definition = JSON.parse(content);
-          const jv = new JSONValidation();
-          let result = jv.validate(definition, definitionSchema);
-          const errorMsg = 'Definition has the following errors: ' + result.errors.join(', ');
-          expect(result.ok, errorMsg).to.be.true;
-        });
-
+        return fs
+          .readFile(path.join(dirname, fname), 'utf-8')
+          .then((content) => {
+            const definition = JSON.parse(content);
+            const jv = new JSONValidation();
+            let result = jv.validate(definition, definitionSchema);
+            const errorMsg =
+              'Definition has the following errors: ' +
+              result.errors.join(', ');
+            expect(result.ok, errorMsg).to.be.true;
+          });
       });
-
     }
-
   });
-
 });

--- a/test/test_enum.js
+++ b/test/test_enum.js
@@ -1,0 +1,275 @@
+require('source-map-support').install();
+
+const run = require('../lib/run').run;
+
+const rimraf = require('rimraf');
+
+const path = require('path');
+
+const fs = require('fs-extra');
+
+const expect = require('chai').expect;
+
+const { mkdtemp, instantiatePythonWidgets } = require('./util');
+
+describe('test_enum', () => {
+  describe('python', () => {
+    it('should generate all the files', () => {
+      let fname = path.resolve(__dirname, 'definitions', 'test_enum.json');
+      let outdir = null;
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['python'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'BaseTestWidget.py',
+                'EnumExplicitDefault.py',
+                'EnumImplicitNullDefault.py',
+                'EnumNullDefault.py',
+                '__init__.py',
+              ]);
+              instantiatePythonWidgets(outdir);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
+        });
+    });
+  });
+
+  describe('javascript', () => {
+    it('should generate all the files', () => {
+      let fname = path.resolve(__dirname, 'definitions', 'test_enum.json');
+      let outdir = null;
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['javascript'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'BaseTestWidget.js',
+                'EnumExplicitDefault.js',
+                'EnumImplicitNullDefault.js',
+                'EnumNullDefault.js',
+                'index.js',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
+        });
+    });
+
+    it('should generate a single file with all the definitions', () => {
+      let fname = path.resolve(__dirname, 'definitions', 'test_enum.json');
+      let outdir = null;
+      let outfile = null;
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          outfile = path.join(outdir, 'widgets.js');
+          return run(fname, ['javascript'], { output: outfile });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql(['widgets.js']);
+              const content = fs.readFileSync(outfile, { encoding: 'utf-8' });
+              const pattern = /^var (\w(\w|[_0-9])*)Model = (\w(\w|[_0-9])*)Model.extend\({$/gm;
+              const names = [];
+              let match;
+              while ((match = pattern.exec(content))) {
+                names.push(match[1]);
+              }
+              expect(names.sort()).to.eql([
+                'BaseTestWidget',
+                'EnumExplicitDefault',
+                'EnumImplicitNullDefault',
+                'EnumNullDefault',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
+        });
+    });
+  });
+
+  describe('ts', () => {
+    it('should generate all the files', () => {
+      let fname = path.resolve(__dirname, 'definitions', 'test_enum.json');
+      let outdir = null;
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['ts'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'BaseTestWidget.ts',
+                'EnumExplicitDefault.ts',
+                'EnumImplicitNullDefault.ts',
+                'EnumNullDefault.ts',
+                'index.ts',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
+        });
+    });
+
+    it('should generate a single file with all the definitions', () => {
+      let fname = path.resolve(__dirname, 'definitions', 'test_enum.json');
+      let outdir = null;
+      let outfile = null;
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          outfile = path.join(outdir, 'widgets.ts');
+          return run(fname, ['ts'], { output: outfile });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql(['widgets.ts']);
+              const content = fs.readFileSync(outfile, { encoding: 'utf-8' });
+              const pattern = /^class (\w(\w|[_0-9])*?)Model extends (\w(\w|[_0-9])*?)Model \{$/gm;
+              const names = [];
+              let match;
+              while ((match = pattern.exec(content))) {
+                names.push(match[1]);
+              }
+              expect(names.sort()).to.eql([
+                'BaseTestWidget',
+                'EnumExplicitDefault',
+                'EnumImplicitNullDefault',
+                'EnumNullDefault',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
+        });
+    });
+  });
+
+  describe('java', () => {
+    it('should generate all the files', () => {
+      let fname = path.resolve(__dirname, 'definitions', 'test_enum.json');
+      let outdir = null;
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          return run(fname, ['java'], { output: outdir });
+        })
+        .then(() => {
+          return fs.readdir(outdir);
+        })
+        .then((dirFiles) => {
+          return new Promise((resolve, reject) => {
+            try {
+              expect(dirFiles).to.eql([
+                'BaseTestWidget.java',
+                'EnumExplicitDefault.java',
+                'EnumImplicitNullDefault.java',
+                'EnumNullDefault.java',
+              ]);
+            } finally {
+              rimraf(outdir, (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+            }
+          });
+        });
+    });
+
+    it('should fail when trying to write to a single file', () => {
+      let fname = path.resolve(__dirname, 'definitions', 'test_enum.json');
+      let outdir = null;
+      let outfile = null;
+      const log = [];
+      const origConsole = console.log;
+      const cleanUp = () => {
+        console.log = origConsole;
+        rimraf(outdir, () => {});
+      };
+      return mkdtemp('widget-gen')
+        .then((d) => {
+          outdir = d;
+          outfile = path.join(outdir, 'widgets.java');
+
+          console.log = (message) => {
+            log.push(message);
+          };
+          return run(fname, ['java'], { output: outfile });
+        })
+        .then(() => {
+          cleanUp();
+          expect(log.length).to.equal(1);
+          expect(log[0]).is.instanceOf(Error);
+          expect(log[0].message).to.eql(
+            'Cannot write multiple widget definitions to one Java file!'
+          );
+        }, cleanUp);
+    });
+  });
+});

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,39 @@
+const path = require('path');
+
+const fs = require('fs-extra');
+
+const os = require('os');
+
+const spawnSync = require('child_process').spawnSync;
+
+function mkdtemp(prefix) {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Test that modules can be imported, and widgets instantiated
+ */
+function instantiatePythonWidgets(outdir) {
+  const cmd = [
+    `MODULE_PATH = ${JSON.stringify(path.join(outdir, '__init__.py'))}`,
+    `MODULE_NAME = 'module_under_test'`,
+    `import importlib`,
+    `import sys`,
+    `spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)`,
+    `module = importlib.util.module_from_spec(spec)`,
+    `sys.modules[spec.name] = module`,
+    `spec.loader.exec_module(module)`,
+    `for w in dir(module):`,
+    `    if not w.startswith('_'):`,
+    `        getattr(module, w)()`,
+  ];
+  const res = spawnSync('python', ['-c', cmd.join('\n')], { encoding: 'utf8' });
+  if (res.status !== 0) {
+    throw new Error(res.stdout.toString() + res.stderr.toString());
+  }
+}
+
+module.exports = {
+  mkdtemp: mkdtemp,
+  instantiatePythonWidgets: instantiatePythonWidgets,
+};


### PR DESCRIPTION
- Register python widgets by default (adds `ipywidgets.register()` to definitions)
- Python parser generates internal spec format directly instead of generating the JSON spec format.
- Python writer now has `makeTrait` and `convertValue` as protected members so subclasses can override/extend.
- Allow default values for object/Dict traits to work in python
- Update some dependencies and clean up some code
- Lint / auto-format some (no hooks yet, just to get the code somewhere clean)
- Expand/fix tests
- Add `enum` and `any` attribute types.