### PR TITLE
Use triple quotes for python help strings

### DIFF
--- a/src/writers/python.ts
+++ b/src/writers/python.ts
@@ -84,7 +84,7 @@ export class PythonWriter extends TemplateWriter {
     } else {
       // JSON object
       if (data.help) {
-        tag = `.tag(sync=True, help='${data.help}')`;
+        tag = `.tag(sync=True, help="""${data.help}""")`;
       }
       let allowNoneArg = '';
       if (data.allowNull !== undefined && data.allowNull !== false) {


### PR DESCRIPTION
Avoids need to escape single/double quotes in help strings